### PR TITLE
fix: 修正 Swagger 文件於 CD 部署流程中未正確更新問題

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -37,6 +37,7 @@ jobs:
             docker-compose down
             docker-compose up -d --build
             docker-compose exec -T app composer install --no-interaction --prefer-dist --optimize-autoloader
+            docker-compose exec -T app rm -rf storage/api-docs
             docker-compose exec -T app php artisan l5-swagger:generate
             docker-compose exec -T app php artisan config:clear
             docker-compose exec -T app php artisan route:clear

--- a/routes/api.php
+++ b/routes/api.php
@@ -19,7 +19,7 @@ Route::middleware('auth:sanctum')->get('/user', function (Request $request) {
     return $request->user();
 });
 
-Route::get('/test', function () {
+Route::get('/testhaha', function () {
     return response()->json([
         'success' => true,
         'stauts' => 200


### PR DESCRIPTION
- 在 GitHub Actions CD 階段加入清除 storage/api-docs 舊資料
- 確保 l5-swagger:generate 每次都能重新產出最新文件
- 避免快取與權限問題導致的部署異常
- 再次測試再次測試route cache