### PR TITLE
feat(post): 實作文章更新功能(含權限與狀態驗證)

### DIFF
--- a/app/Http/Controllers/Api/PostController.php
+++ b/app/Http/Controllers/Api/PostController.php
@@ -7,6 +7,8 @@ use App\Http\Requests\StorePostRequest;
 use App\Http\Resources\PostResource;
 use App\Services\PostService;
 use Exception;
+use Illuminate\Database\Eloquent\ModelNotFoundException;
+use Illuminate\Auth\Access\AuthorizationException;
 use Illuminate\Http\Response;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
@@ -45,6 +47,48 @@ class PostController extends Controller
                 'success' => false,
                 'status' => $e->getCode() ?: Response::HTTP_INTERNAL_SERVER_ERROR,
                 'message' => '伺服器錯誤，請稍後再試',
+                'data' => null
+            ], $e->getCode() ?: Response::HTTP_INTERNAL_SERVER_ERROR);
+        }
+    }
+
+    /**
+     * 更新文章
+     * 
+     * @param StorePostRequest $request (共用 store 的 Request)
+     * @param int $id 路由傳入之文章 ID
+     * @return JsonResponse 
+     */
+    public function update(StorePostRequest $request, int $id): JsonResponse
+    {
+        try {
+            $post = $this->postService->updatePost($id, $request->validated());
+
+            return response()->json([
+                'success' => true,
+                'status' => Response::HTTP_OK,
+                'message' => '修改文章成功',
+                'data' => new PostResource($post)
+            ], Response::HTTP_OK);
+        } catch (ModelNotFoundException $e) {
+            return response()->json([
+                'success' => false,
+                'status' => Response::HTTP_NOT_FOUND,
+                'message' => '找不到該文章',
+                'data' => null
+            ], Response::HTTP_NOT_FOUND);
+        } catch (AuthorizationException $e) {
+            return response()->json([
+                'success' => false,
+                'status' => Response::HTTP_FORBIDDEN,
+                'message' => '你沒有權限修改該文章',
+                'data' => null
+            ], Response::HTTP_FORBIDDEN);
+        } catch (Exception $e) {
+            return response()->json([
+                'success' => false,
+                'status' => $e->getCode() ?: Response::HTTP_INTERNAL_SERVER_ERROR,
+                'message' => $e->getMessage(),
                 'data' => null
             ], $e->getCode() ?: Response::HTTP_INTERNAL_SERVER_ERROR);
         }

--- a/app/Policies/PostPolicy.php
+++ b/app/Policies/PostPolicy.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace App\Policies;
+
+use App\Models\Post;
+use App\Models\User;
+use Illuminate\Auth\Access\Response;
+
+class PostPolicy
+{
+    /**
+     * Determine whether the user can view any models.
+     */
+    public function viewAny(User $user): bool
+    {
+        //
+    }
+
+    /**
+     * Determine whether the user can view the model.
+     */
+    public function view(User $user, Post $post): bool
+    {
+        //
+    }
+
+    /**
+     * Determine whether the user can create models.
+     */
+    public function create(User $user): bool
+    {
+        //
+    }
+
+    /**
+     * 判斷使用者是否可更新文章
+     * 
+     * @param User $user
+     * @param Post $post 
+     * @return bool
+     */
+    public function update(User $user, Post $post): bool
+    {
+        return $user->id === $post->user_id;
+    }
+
+    /**
+     * Determine whether the user can delete the model.
+     */
+    public function delete(User $user, Post $post): bool
+    {
+        //
+    }
+
+    /**
+     * Determine whether the user can restore the model.
+     */
+    public function restore(User $user, Post $post): bool
+    {
+        //
+    }
+
+    /**
+     * Determine whether the user can permanently delete the model.
+     */
+    public function forceDelete(User $user, Post $post): bool
+    {
+        //
+    }
+}

--- a/app/Providers/AuthServiceProvider.php
+++ b/app/Providers/AuthServiceProvider.php
@@ -4,6 +4,8 @@ namespace App\Providers;
 
 // use Illuminate\Support\Facades\Gate;
 use Illuminate\Foundation\Support\Providers\AuthServiceProvider as ServiceProvider;
+use App\Models\Post;
+use App\Policies\PostPolicy;
 
 class AuthServiceProvider extends ServiceProvider
 {
@@ -13,7 +15,7 @@ class AuthServiceProvider extends ServiceProvider
      * @var array<class-string, class-string>
      */
     protected $policies = [
-        //
+        Post::class => PostPolicy::class,
     ];
 
     /**

--- a/app/Repositories/PostRepository.php
+++ b/app/Repositories/PostRepository.php
@@ -21,4 +21,28 @@ class PostRepository
     {
         return Post::create($data);
     }
+
+    /**
+     * 依 ID 取得單篇文章
+     * 
+     * @param int $id 
+     * @return Post
+     * @throws \Illuminate\Database\Eloquent\ModelNotFoundException
+     */
+    public function findPostById(int $id): Post
+    {
+        return Post::findOrFail($id);
+    }
+
+    /**
+     * 更新文章
+     * 
+     * @param Post $post 
+     * @param array $data 
+     * @return bool
+     */
+    public function updatePost(Post $post, array $data): bool
+    {
+        return $post->update($data);
+    }
 }

--- a/app/Services/PostService.php
+++ b/app/Services/PostService.php
@@ -2,9 +2,12 @@
 
 namespace App\Services;
 
+use App\Models\Post;
 use App\Repositories\PostRepository;
 use Illuminate\Support\Facades\Auth;
-use App\Models\Post;
+use Illuminate\Support\Facades\Gate; // or use $this->authorize in Controller
+use Illuminate\Auth\Access\AuthorizationException;
+use Illuminate\Database\Eloquent\ModelNotFoundException;
 
 /**
  * 
@@ -30,6 +33,36 @@ class PostService
         $post = $this->postRepository->createPost($data);
 
         // 預載 user 關聯，避免 Resource 那邊變 null 或 lazy loading
+        return $post->load('user');
+    }
+
+    /**
+     * 更新文章
+     * 
+     * @param int $id 文章 ID
+     * @param array $data 更新的資料
+     * @return Post 
+     * @throws AuthorizationException
+     * @throws ModelNotFoundException
+     * @throws \Exception 嘗試將已發布之文章改為草稿
+     */
+    public function updatePost(int $id, array $data): Post
+    {
+        // 查詢文章，找不到會自動拋出 ModelNotFoundException
+        $post = $this->postRepository->findPostById($id);
+
+        // 使用 Policy 檢查權限
+        // 使用 Gate::authorize() 或 $this->authorize()
+        // 當不通過時 Laravel 自動會拋出 AuthorizationException
+        Gate::authorize('update', $post);
+
+        // 限制 已發布之文章不能更改為草稿
+        if ($post->status === 2 && isset($data['status']) && $data['status'] === 1) {
+            throw new \Exception('已發布的文章不能更改為草稿狀態', 422);
+        }
+
+        $this->postRepository->updatePost($post, $data);
+
         return $post->load('user');
     }
 }

--- a/app/Swagger/Post.php
+++ b/app/Swagger/Post.php
@@ -72,6 +72,106 @@ namespace App\Swagger;
  *              @OA\Property(property="data", type="string", nullable=true, example=null)
  *          )
  *      )
+ * ),
+ * 
+ * @OA\Put(
+ *     path="/api/posts/{id}",
+ *     summary="更新文章",
+ *     tags={"Post"},
+ *     description="已登入使用者可更新自己建立的文章。若文章狀態已發布，則無法改為草稿。",
+ *     operationId="updatePost",
+ *     security={{"bearerAuth":{}}},
+ *  
+ *     @OA\Parameter(
+ *         name="id",
+ *         in="path",
+ *         description="文章 ID",
+ *         required=true,
+ *         @OA\Schema(type="integer", example=1)
+ *     ),
+ *  
+ *     @OA\RequestBody(
+ *         required=true,
+ *         @OA\JsonContent(ref="#/components/schemas/StorePostRequest")
+ *     ),
+ * 
+ *     @OA\Response(
+ *         response=200,
+ *         description="文章更新成功",
+ *         @OA\JsonContent(ref="#/components/schemas/PostResource")
+ *     ),
+ * 
+ *     @OA\Response(
+ *         response=403,
+ *         description="無權限修改文章",
+ *         @OA\JsonContent(
+ *             @OA\Property(property="success", type="boolean", example=false),
+ *             @OA\Property(property="status", type="integer", example=403),
+ *             @OA\Property(property="message", type="string", example="你沒有權限修改該文章"),
+ *             @OA\Property(property="data", type="string", example=null)
+ *         )
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=404,
+ *         description="找不到該文章",
+ *         @OA\JsonContent(
+ *             @OA\Property(property="success", type="boolean", example=false),
+ *             @OA\Property(property="status", type="integer", example=404),
+ *             @OA\Property(property="message", type="string", example="找不到該文章"),
+ *             @OA\Property(property="data", type="string", example=null)
+ *         )
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=422,
+ *         description="驗證失敗或無法變更狀態",
+ *         @OA\JsonContent(
+ *             oneOf={
+ *                 @OA\Schema(
+ *                     @OA\Property(property="success", type="boolean", example=false),
+ *                     @OA\Property(property="status", type="integer", example=422),
+ *                     @OA\Property(property="message", type="string", example="已發布的文章不能更改為草稿狀態"),
+ *                     @OA\Property(property="data", type="string", example=null)
+ *                 ),
+ *                 @OA\Schema(
+ *                     @OA\Property(property="success", type="boolean", example=false),
+ *                     @OA\Property(property="status", type="integer", example=422),
+ *                     @OA\Property(property="message", type="string", example="驗證失敗"),
+ *                     @OA\Property(
+ *                         property="errors",
+ *                         type="object",
+ *                         @OA\Property(
+ *                             property="title",
+ *                             type="array",
+ *                             @OA\Items(type="string", example="標題會必填")
+ *                         ),
+ *                         @OA\Property(
+ *                             property="content",
+ *                             type="array",
+ *                             @OA\Items(type="string", example="文章內容為必填")
+ *                         ),
+ *                         @OA\Property(
+ *                             property="status",
+ *                             type="array",
+ *                             @OA\Items(type="string", example="狀態為必填")
+ *                         )
+ *                     )
+ *                 )
+ *             }
+ *         )
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=500,
+ *         description="伺服器錯誤",
+ *         @OA\JsonContent(
+ *             @OA\Property(property="success", type="boolean", example=false),
+ *             @OA\Property(property="status", type="integer", example=500),
+ *             @OA\Property(property="message", type="string", example="伺服器錯誤請稍後再試"),
+ *             @OA\Property(property="data", type="string", example=null)
+ *         )
+ *     )
  * )
  */
 

--- a/routes/api.php
+++ b/routes/api.php
@@ -37,4 +37,6 @@ Route::prefix('user')->group(function () {
 Route::middleware('auth:api')->prefix('posts')->group(function () {
     // 新增文章
     Route::post('/', [PostController::class, 'store']);
+    // 更新文章
+    Route::PUT('/{id}', [PostController::class, 'update']);
 });


### PR DESCRIPTION
- 新增 PostController@update 方法，支援僅文章擁有者可編輯文章
- 使用 Gate::authorize 驗證使用者權限
- 限制已發布的文章不得改為草稿
- 共用 StorePostRequest 與 PostResource
- 新增 Swagger 文件 文章更新之部分