### PR TITLE
feature(comment): 完成修改留言功能並修正 CD 工作流程

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -32,17 +32,37 @@ jobs:
         run: |
           ssh ${{ secrets.EC2_USER }}@${{ secrets.EC2_HOST }} << 'EOF'
             cd ${{ secrets.EC2_PATH }}
+
+            echo " 拉取最新程式碼..."
             git config --global --add safe.directory /var/www
             git pull origin main
+
+            echo " 重建並啟動 Docker 容器..."
             docker-compose down
             docker-compose up -d --build
+
+            echo " 等待 app 容器啟動..."
+            until docker compose exec -T app test -f artisan; do
+              echo "等待容器啟動中..."
+              sleep 5
+            done
+
+            echo " 安裝 Composer 套件..."
             docker-compose exec -T app composer install --no-interaction --prefer-dist --optimize-autoloader
+
+            echo " 設定 Swagger 權限與生成文件..."
             docker-compose exec -T app chown -R www-data:www-data storage/api-docs
             docker-compose exec -T app chmod -R 775 storage/api-docs
             docker-compose exec -T app php artisan l5-swagger:generate
+
+            echo " 快取與設定清理..."
             docker-compose exec -T app php artisan config:clear
             docker-compose exec -T app php artisan route:clear
             docker-compose exec -T app php artisan config:cache
             docker-compose exec -T app php artisan route:cache
+
+            echo " 執行 migrate..."
             docker-compose exec -T app php artisan migrate --force
+
+            echo "部署完成！"
           EOF

--- a/app/Http/Controllers/Api/CommentController.php
+++ b/app/Http/Controllers/Api/CommentController.php
@@ -58,4 +58,47 @@ class CommentController extends Controller
             ], $e->getCode() ?: Response::HTTP_INTERNAL_SERVER_ERROR);
         }
     }
+
+    /**
+     * 修改文章留言
+     * 
+     * @param StoreCommentRequest $request
+     * @param int $postId
+     * @param int $commentId
+     * @return JsonResponse
+     */
+    public function update(StoreCommentRequest $request, int $postId, int $commentId): JsonResponse
+    {
+        try {
+            $comment = $this->commentService->updateComment($postId, $commentId, $request->validated());
+
+            return response()->json([
+                'success' => true,
+                'status' => Response::HTTP_OK,
+                'message' => '修改留言成功',
+                'data' => new CommentResource($comment)
+            ], Response::HTTP_OK);
+        } catch (ModelNotFoundException $e) {
+            return response()->json([
+                'success' => false,
+                'status' => Response::HTTP_NOT_FOUND,
+                'message' => $e->getMessage(),
+                'data' => null
+            ], Response::HTTP_NOT_FOUND, );
+        } catch (AuthorizationException $e) {
+            return response()->json([
+                'success' => false,
+                'status' => Response::HTTP_FORBIDDEN,
+                'message' => $e->getMessage(),
+                'data' => null
+            ], Response::HTTP_FORBIDDEN); 
+        } catch (Exception $e) {
+            return response()->json([
+                'success' => false,
+                'status' => $e->getCode() ?: Response::HTTP_INTERNAL_SERVER_ERROR,
+                'message' => '伺服器錯誤，請稍後再試',
+                'data' => null
+            ], $e->getCode() ?: Response::HTTP_INTERNAL_SERVER_ERROR);
+        }
+    }
 }

--- a/app/Http/Controllers/Api/PostController.php
+++ b/app/Http/Controllers/Api/PostController.php
@@ -74,7 +74,7 @@ class PostController extends Controller
             return response()->json([
                 'success' => false,
                 'status' => Response::HTTP_NOT_FOUND,
-                'message' => '找不到該文章',
+                'message' => $e->getMessage(),
                 'data' => null
             ], Response::HTTP_NOT_FOUND);
         } catch (AuthorizationException $e) {

--- a/app/Policies/CommentPolicy.php
+++ b/app/Policies/CommentPolicy.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace App\Policies;
+
+use App\Models\Comment;
+use App\Models\User;
+use Illuminate\Auth\Access\Response;
+
+class CommentPolicy
+{
+    /**
+     * Determine whether the user can view any models.
+     */
+    public function viewAny(User $user): bool
+    {
+        //
+    }
+
+    /**
+     * Determine whether the user can view the model.
+     */
+    public function view(User $user, Comment $comment): bool
+    {
+        //
+    }
+
+    /**
+     * Determine whether the user can create models.
+     */
+    public function create(User $user): bool
+    {
+        //
+    }
+
+    /**
+     * Determine whether the user can update the model.
+     */
+    public function update(User $user, Comment $comment): bool
+    {
+        // 使用者是留言的作者且該留言屬於該文章
+        return $user->id === $comment->user_id;
+    }
+
+    /**
+     * Determine whether the user can delete the model.
+     */
+    public function delete(User $user, Comment $comment): bool
+    {
+        //
+    }
+
+    /**
+     * Determine whether the user can restore the model.
+     */
+    public function restore(User $user, Comment $comment): bool
+    {
+        //
+    }
+
+    /**
+     * Determine whether the user can permanently delete the model.
+     */
+    public function forceDelete(User $user, Comment $comment): bool
+    {
+        //
+    }
+}

--- a/app/Providers/AuthServiceProvider.php
+++ b/app/Providers/AuthServiceProvider.php
@@ -4,7 +4,9 @@ namespace App\Providers;
 
 // use Illuminate\Support\Facades\Gate;
 use Illuminate\Foundation\Support\Providers\AuthServiceProvider as ServiceProvider;
+use App\Models\Comment;
 use App\Models\Post;
+use App\Policies\CommentPolicy;
 use App\Policies\PostPolicy;
 
 class AuthServiceProvider extends ServiceProvider
@@ -16,6 +18,7 @@ class AuthServiceProvider extends ServiceProvider
      */
     protected $policies = [
         Post::class => PostPolicy::class,
+        Comment::class => CommentPolicy::class,
     ];
 
     /**

--- a/app/Repositories/CommentRepository.php
+++ b/app/Repositories/CommentRepository.php
@@ -3,6 +3,7 @@
 namespace App\Repositories;
 
 use App\Models\Comment;
+use Illuminate\Database\Eloquent\ModelNotFoundException;
 
 /**
  * Class CommentRepository
@@ -19,5 +20,33 @@ class CommentRepository
     public function createComment(array $data): Comment 
     {
         return Comment::create($data);
+    }
+
+    /**
+     * 依留言 ID  取得該留言
+     * 
+     * @param int $id
+     * @return Comment
+     * @throws \Illuminate\Database\Eloquent\ModelNotFoundException
+     */
+    public function findCommentByID(int $id): Comment
+    {
+        try {
+            return Comment::findOrFail($id);
+        } catch (ModelNotFoundException $e) {
+            throw new ModelNotFoundException("該留言不存在");
+        }
+    }
+
+    /**
+     * 修改留言
+     * 
+     * @param Comment $comment
+     * @param array $data
+     * @return bool
+     */
+    public function updateComment(Comment $comment, array $data): bool
+    {
+        return $comment->update($data);
     }
 }

--- a/app/Repositories/PostRepository.php
+++ b/app/Repositories/PostRepository.php
@@ -3,6 +3,7 @@
 namespace App\Repositories;
 
 use App\Models\Post;
+use Illuminate\Database\Eloquent\ModelNotFoundException;
 
 /**
  * Class PostRepository
@@ -31,7 +32,13 @@ class PostRepository
      */
     public function findPostById(int $id): Post
     {
-        return Post::findOrFail($id);
+        // return Post::findOrFail($id);
+
+        try {
+            return Post::findOrFail($id);
+        } catch (ModelNotFoundException $e) {
+            throw new ModelNotFoundException("找不到該文章");
+        }
     }
 
     /**

--- a/app/Swagger/Comment.php
+++ b/app/Swagger/Comment.php
@@ -86,7 +86,104 @@ namespace App\Swagger;
  *             @OA\Property(property="data", type="null", example=null)
  *         )
  *     )
+ * ),
+ * 
+ *  * @OA\Put(
+ *     path="/api/posts/{post}/comments/{comment}",
+ *     summary="修改留言",
+ *     description="使用者可修改自己對文章的留言，需通過權限與資料一致性驗證（該留言必須屬於該文章）",
+ *     tags={"Comment"},
+ *     security={{"bearerAuth":{}}},
+ *     @OA\Parameter(
+ *         name="post",
+ *         in="path",
+ *         required=true,
+ *         description="文章 ID",
+ *         @OA\Schema(type="integer", example=1)
+ *     ),
+ *     @OA\Parameter(
+ *         name="comment",
+ *         in="path",
+ *         required=true,
+ *         description="留言 ID",
+ *         @OA\Schema(type="integer", example=1)
+ *     ),
+ *     @OA\RequestBody(
+ *         required=true,
+ *         @OA\JsonContent(
+ *             required={"content"},
+ *             @OA\Property(property="content", type="string", example="這是我修改後的留言內容")
+ *         )
+ *     ),
+ *     @OA\Response(
+ *         response=200,
+ *         description="留言修改成功",
+ *         @OA\JsonContent(
+ *             @OA\Property(property="success", type="boolean", example=true),
+ *             @OA\Property(property="status", type="integer", example=200),
+ *             @OA\Property(property="message", type="string", example="修改留言成功"),
+ *             @OA\Property(
+ *                 property="data",
+ *                 type="object",
+ *                 @OA\Property(property="id", type="integer", example=3),
+ *                 @OA\Property(property="content", type="string", example="這是我修改後的留言內容"),
+ *                 @OA\Property(property="user_id", type="integer", example=5),
+ *                 @OA\Property(property="post_id", type="integer", example=1),
+ *                 @OA\Property(property="created_at", type="string", example="2025-05-30 12:00:00"),
+ *                 @OA\Property(property="updated_at", type="string", example="2025-05-30 13:00:00")
+ *             )
+ *         )
+ *     ),
+ *     @OA\Response(
+ *         response=403,
+ *         description="留言不屬於該文章或無權限修改留言",
+ *         @OA\JsonContent(
+ *             @OA\Property(property="success", type="boolean", example=false),
+ *             @OA\Property(property="status", type="integer", example=403),
+ *             @OA\Property(property="message", type="string", example="你沒有權限修改留言 或 此留言不屬於該文章，故無法更改"),
+ *             @OA\Property(property="data", type="string", nullable=true, example=null)
+ *         )
+ *     ),
+ *     @OA\Response(
+ *         response=404,
+ *         description="找不到留言或文章",
+ *         @OA\JsonContent(
+ *             @OA\Property(property="success", type="boolean", example=false),
+ *             @OA\Property(property="status", type="integer", example=404),
+ *             @OA\Property(property="message", type="string", example="該留言不存在 或 找不到該文章"),
+ *             @OA\Property(property="data", type="string", nullable=true, example=null)
+ *         )
+ *     ),
+ *     @OA\Response(
+ *         response=422,
+ *         description="驗證失敗",
+ *         @OA\JsonContent(
+ *             @OA\Property(property="success", type="boolean", example=false),
+ *             @OA\Property(property="status", type="integer", example=422),
+ *             @OA\Property(property="message", type="string", example="驗證失敗"),
+ *             @OA\Property(
+ *                 property="errors",
+ *                 type="object",
+ *                 @OA\Property(
+ *                     property="content",
+ *                     type="array",
+ *                     @OA\Items(type="string", example="留言內容不得為空")
+ *                 )
+ *             )
+ *         )
+ *     ),
+ *     @OA\Response(
+ *         response=500,
+ *         description="伺服器錯誤",
+ *         @OA\JsonContent(
+ *             @OA\Property(property="success", type="boolean", example=false),
+ *             @OA\Property(property="status", type="integer", example=500),
+ *             @OA\Property(property="message", type="string", example="伺服器錯誤，請稍後再試"),
+ *             @OA\Property(property="data", type="string", nullable=true, example=null)
+ *         )
+ *     )
  * )
+ * 
  */
 
 class Comment {}

--- a/routes/api.php
+++ b/routes/api.php
@@ -45,5 +45,7 @@ Route::middleware('auth:api')->group(function () {
 
         // 對文章新增留言
         Route::post('/{post}/comments', [CommentController::class, 'store']);
+        // 修改留言
+        Route::PUT('/{post}/comments/{comment}', [CommentController::class, 'update']);
     });
 });


### PR DESCRIPTION
- 新增 CommentController 的 update 方法
- 使用 StoreCommentRequest 作為驗證（與新增共用）
- 建立 CommentService 的 updateComment 邏輯
- 使用 CommentPolicy 驗證使用者只能修改自己的留言
- 加入額外判斷：留言必須屬於對應文章，否則禁止修改
- 在 CommentRepository 中新增 updateComment 方法
- 調整PostRepository 之 findPostById 回傳之錯誤訊息客製化，同步調整於 PostController 的找不到文章之錯誤訊息改為抓 $e->getMessage
- 調整 api.php 路由：新增 PUT /posts/{post}/comments/{comment}
- 撰寫 Swagger 文件說明留言修改 API 行為與錯誤情境（403、404、500）
- 修正 .github/workflows/deploy.yml：
  - 確保容器啟動後再執行 artisan 指令
  - 新增錯誤處理與等待機制，確保 l5-swagger:generate 與 migrate 能正常執行