### PR TITLE
feat(short-url): 新增短網址建立功能 (Controller + Service + Repository + Swagger)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,10 @@ RUN apt-get update && apt-get install -y \
     libonig-dev \
     libxml2-dev \
     zip unzip git curl \
-    && docker-php-ext-install pdo_mysql mbstring exif pcntl bcmath gd
+    && docker-php-ext-install pdo_mysql mbstring exif pcntl bcmath gd \
+    # 安裝 Redis 擴展
+    && pecl install redis \
+    && docker-php-ext-enable redis
 
 # 從官方 composer image 直接複製 composer 可執行檔進來。
 COPY --from=composer:latest /usr/bin/composer /usr/bin/composer

--- a/app/Http/Controllers/Api/ShortUrlController.php
+++ b/app/Http/Controllers/Api/ShortUrlController.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use App\Http\Requests\StoreShortUrlRequest;
+use App\Http\Resources\ShortUrlResource;
+use App\Services\ShortUrlService;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Http\Response;
+use Exception;
+
+/**
+ * 短網址 API 控制器 (受 JWT 保護)
+ */
+class ShortUrlController extends Controller
+{
+    public function __construct(
+        private ShortUrlService $shortUrlService
+    ) {}
+
+    /**
+     * 建立短網址
+     * @param StoreShortUrlRequest $request 驗證後請求
+     * @return JsonResponse
+     */
+    public function store(StoreShortUrlRequest $request): JsonResponse
+    {
+        try {
+            $userId = (int) auth()->id();
+            $short = $this->shortUrlService->create($userId, $request->validated());
+
+            return response()->json([
+                'success' => true,
+                'status' => Response::HTTP_CREATED,
+                'message' => '短網址建立成功',
+                'data' => new ShortUrlResource($short),
+            ], Response::HTTP_CREATED);
+        } catch (Exception $e) {
+            return response()->json([
+                'success' => false,
+                'status' => $e->getCode() ?: Response::HTTP_INTERNAL_SERVER_ERROR,
+                'message' => $e->getMessage(),
+                'data' => null
+            ], $e->getCode() ?: Response::HTTP_INTERNAL_SERVER_ERROR);
+        }
+    }
+}

--- a/app/Http/Requests/StoreShortUrlRequest.php
+++ b/app/Http/Requests/StoreShortUrlRequest.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class StoreShortUrlRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * 規則
+     * - original_url: 必填且為 URL
+     * - short_code: 可選、英數、長度 4 ~32、唯一
+     * - expired_at: 可選、日期、必需晚於現在
+     * @return array<string, \Illuminate\Contracts\Validation\ValidationRule|array<mixed>|string>
+     */
+    public function rules(): array
+    {
+        return [
+            'original_url' => ['required', 'url', 'max:2048'],
+            'short_code' => ['nullable', 'regex:/^[A-Za-z0-9]{4,32}$/', 'unique:short_urls,short_code'],
+            'expired_at' => ['nullable', 'date', 'after:now'],
+        ];
+    }
+
+    /**
+     * 
+     * @return array
+     */
+    public function messages(): array
+    {
+        return [
+            'original_url.required' => '原始網址為必填',
+            'original_url.url' => '原始網址必須為正確之 URL 格式',
+            'short_code.regex' => '短碼僅能包含英數字，長度 4~32。',
+            'short_code.unique' => '該短網址已被使用',
+            'expired_at.after' => '過期時間必須比今日晚',
+            'expired_at.date' => '過期時間必須為日期格式 xxxx-yy-zz 00:00:00'
+        ];
+    }
+}

--- a/app/Http/Resources/ShortUrlResource.php
+++ b/app/Http/Resources/ShortUrlResource.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Http\Resources;
+
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+use App\Http\Resources\Traits\FormatTimestamps;
+
+class ShortUrlResource extends JsonResource
+{
+    use FormatTimestamps;
+
+    /**
+     * Transform the resource into an array.
+     *
+     * @return array<string, mixed>
+     */
+    public function toArray(Request $request): array
+    {
+        return [
+            'id' => $this->id,
+            'short_code' => $this->short_code,
+            'original_url' => $this->original_url,
+            'click_count' => $this->click_count,
+            'expired_at'   => $this->formatDateTime($this->expired_at),
+            'created_at'   => $this->formatDateTime($this->created_at),
+            'updated_at'   => $this->formatDateTime($this->updated_at),
+        ];
+    }
+}

--- a/app/Models/ShortUrl.php
+++ b/app/Models/ShortUrl.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class ShortUrl extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'user_id',
+        'original_url',
+        'short_code',
+        'click_count',
+        'expired_at',
+    ];
+
+    protected $casts = [
+        'expired_at' => 'datetime',
+    ];
+
+    /**
+     * 建立者
+     * @return BelongsTo
+     */
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(User::class);
+    }
+}

--- a/app/Repositories/ShortUrlRepository.php
+++ b/app/Repositories/ShortUrlRepository.php
@@ -1,0 +1,33 @@
+<?php 
+
+namespace App\Repositories;
+
+use App\Models\ShortUrl;
+use Illuminate\Contracts\Pagination\LengthAwarePaginator;
+use Illuminate\Database\QueryException;
+
+class ShortUrlRepository
+{
+    /**
+     * 建立
+     *
+     * @param array{user_id:int,original_url:string,short_code:string,expired_at?:string|null} $data
+     * @return ShortUrl
+     * @throws QueryException
+     */
+    public function create(array $data): ShortUrl
+    {
+        return ShortUrl::create($data);
+    }
+
+    /**
+     * 檢查短碼是否存在
+     * 
+     * @param string $code 短碼
+     * @return bool
+     */
+    public function existsCode(string $code): bool
+    {
+        return ShortUrl::where('short_code', $code)->exists();
+    }
+}

--- a/app/Services/ShortUrlService.php
+++ b/app/Services/ShortUrlService.php
@@ -1,0 +1,144 @@
+<?php 
+
+namespace App\Services;
+
+use App\Models\ShortUrl;
+use App\Repositories\ShortUrlRepository;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Redis;
+use Illuminate\Support\Str;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Database\QueryException;
+use Exception;
+use Illuminate\Database\Events\QueryExecuted;
+
+/**
+ * 短網址服務層
+ */
+class ShortUrlService
+{
+    public const CACHE_KEY_CODE_PREFIX = 'short:code:'; // 短碼 -> 短網址模型
+    public const REDIS_KEY_CLICK_PREFIX = 'short:clicks:'; // 點擊累積（待回寫）
+
+    public function __construct(private ShortUrlRepository $shortUrlRepository) {}
+
+    /**
+     * 建立短網址
+     * 
+     * @param int $userId 使用者 ID
+     * @param array $payload original_url/short_code/expired_at
+     * @return ShortUrl
+     * @throws Exception
+     */
+    public function create(int $userId, array $payload): ShortUrl
+    {
+        $original = $payload['original_url'];
+        $custom = $payload['short_code'] ?? null;
+        $expired = $payload['expired_at'] ?? null;
+
+        if ($custom !== null) {
+            $this->assertCodeAllowed($custom);
+            if ($this->shortUrlRepository->existsCode($custom)) {
+                throw new Exception('該短碼已被使用', 422);
+            }
+            $code = $custom;
+        } else {
+            $code = $this->generateUniqueCode();
+        }
+
+        try {
+            $short = DB::transaction(function () use ($userId, $original, $code, $expired) {
+                return $this->shortUrlRepository->create([
+                    'user_id'      => $userId,
+                    'original_url' => $original,
+                    'short_code'   => $code,
+                    'click_count' => 0,
+                    'expired_at'   => $expired,
+                ]);
+            });
+        } catch (QueryException $e) {
+            if ($custom === null) {
+                // 碰撞重試一次
+                $code = $this->generateUniqueCode();
+                $short = $this->shortUrlRepository->create([
+                    'user_id'      => $userId,
+                    'original_url' => $original,
+                    'short_code'   => $code,
+                    'click_count' => 0,
+                    'expired_at'   => $expired,
+                ]);
+            } else {
+                throw new Exception('該短碼已被使用', 422);
+            }
+        }
+
+        // 預先快取
+        $this->cacheShort($short);
+
+        return $short;
+    }
+
+    /**
+     * 保留字檢查
+     * 
+     * @param string $code 短碼
+     * @return void
+     * @throws Exception
+     */
+    protected function assertCodeAllowed(string $code): void
+    {
+        $reserved = ['api', 'r', 'admin', 'login', 'logout'];
+        if (in_array(strtolower($code), $reserved, true)) {
+            throw new Exception('該短碼為系統保留字', 422);
+        }
+    }
+
+    /**
+     * 產生唯一短碼（base62）
+     *
+     * @return string
+     */
+    protected function generateUniqueCode(): string
+    {
+        for ($i = 0; $i < 5; $i++) {
+            $code = $this->base62(random_bytes(6));
+            $code = substr($code, 0, 8);
+            if (!$this->shortUrlRepository->existsCode($code)) {
+                return $code;
+            }
+        }
+        return Str::random(10);
+    }
+
+    /**
+     * Base62 編碼
+     *
+     * @param string $bytes 原始位元資料
+     * @return string
+     */
+    protected function base62(string $bytes): string
+    {
+        $alphabet = '0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz';
+        $num = 0;
+        foreach (str_split($bytes) as $chr) {
+            $num = ($num << 8) + ord($chr);
+        }
+        $out = '';
+        while ($num > 0) {
+            $out = $alphabet[$num % 62] . $out;
+            $num = intdiv($num, 62);
+        }
+        return $out ?: '0';
+    }
+
+    /**
+     * 快取短碼對應資料
+     *
+     * @param ShortUrl $short 模型
+     * @return void
+     */
+    protected function cacheShort(ShortUrl $short): void
+    {
+        Cache::put(self::CACHE_KEY_CODE_PREFIX . $short->short_code, $short, 3600);
+    }
+}

--- a/app/Swagger/ShortUrl.php
+++ b/app/Swagger/ShortUrl.php
@@ -1,0 +1,118 @@
+<?php 
+
+namespace App\Swagger;
+
+/**
+     * @OA\Post(
+     *     path="/api/short-urls",
+     *     summary="建立短網址",
+     *     tags={"ShortUrl"},
+     *     description="已登入之使用者才能建立短網址",
+     *     security={{"bearerAuth":{}}},
+     *     
+     * @OA\RequestBody(
+     *     required=true,
+     *     description="用於新增短網址的欄位",
+     *     @OA\MediaType(
+     *         mediaType="application/json",
+     *         @OA\Schema(
+     *             title="新增短網址請求欄位",
+     *             type="object",
+     *             required={"original_url"},
+     *             @OA\Property(property="original_url", type="string", *maxLength=2048, example="https://example.com/page?a=1"),
+     *             @OA\Property(property="short_code",   type="string", nullable=true, description="自訂短碼（英數 4~32）", example="erictest01"),
+     *             @OA\Property(property="expired_at",   type="string", format="date-time", nullable=true, example="2025-12-12 12:00:00")
+     *           )
+     *       )
+     *   ),
+     *
+     *     @OA\Response(
+     *         response=201,
+     *         description="短網址建立成功",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="success", type="boolean", example=true),
+     *             @OA\Property(property="status",  type="integer", example=201),
+     *             @OA\Property(property="message", type="string",  example="短網址建立成功"),
+     *             @OA\Property(
+     *                 property="data",
+     *                 type="object",
+     *                 @OA\Property(property="id",           type="integer", example=1),
+     *                 @OA\Property(property="short_code",   type="string",  example="erictest01"),
+     *                 @OA\Property(property="original_url", type="string",  example="https://www.youtube.com/watch?v=nuRP6Xu-QG4"),
+     *                 @OA\Property(property="click_count",  type="integer", example=0),
+     *                 @OA\Property(property="expired_at",   type="string",  format="date-time", nullable=true, example="2025-12-12 12:00:00"),
+     *                 @OA\Property(property="created_at",   type="string",  format="date-time", example="2025-08-12 00:55:29"),
+     *                 @OA\Property(property="updated_at",   type="string",  format="date-time", example="2025-08-12 00:55:29")
+     *             )
+     *         )
+     *     ),
+     *
+     *     @OA\Response(
+     *         response=401,
+     *         description="尚未授權，請登入（無效的JWT）",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="success", type="boolean", example=false),
+     *             @OA\Property(property="status",  type="integer", example=401),
+     *             @OA\Property(property="message", type="string",  example="尚未授權，請登入"),
+     *             @OA\Property(property="data",    type="string",  nullable=true, example=null)
+     *         )
+     *     ),
+     * 
+     *     @OA\Response(
+     *         response=422,
+     *         description="驗證或業務規則失敗",
+     *         @OA\JsonContent(
+     *             oneOf={
+     *                 @OA\Schema(
+     *                     title="欄位驗證失敗",
+     *                     type="object",
+     *                     example={
+     *                         "success": false,
+     *                         "status": 422,
+     *                         "message": "驗證失敗",
+     *                         "errors": {
+     *                             "original_url": {"原始網址為必填","原始網址必須為正確之 URL 格式"},
+     *                             "short_code":   {"短碼僅能包含英數字，長度 4~32。","短網址重複"},
+     *                             "expired_at":   {"過期時間必須比今日晚","過期時間必須為日期格式 xxxx-yy-zz 00:00:00"}
+     *                         },
+     *                         "data": null
+     *                     }
+     *                 ),
+     *                 @OA\Schema(
+     *                     title="業務規則：短碼為系統保留字",
+     *                     type="object",
+     *                     example={
+     *                         "success": false,
+     *                         "status": 422,
+     *                         "message": "該短碼為系統保留字",
+     *                         "data": null
+     *                     }
+     *                 ),
+     *                 @OA\Schema(
+     *                     title="業務規則：短碼已被使用",
+     *                      type="object",
+     *                     example={
+     *                         "success": false,
+     *                         "status": 422,
+     *                         "message": "該短碼已被使用",
+     *                         "data": null
+     *                     }
+     *                 )
+     *             }
+     *         )
+     *     ),
+     * 
+     *     @OA\Response(
+     *         response=500,
+     *         description="系統錯誤（DB 寫入失敗、未預期例外）",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="success", type="boolean", example=false),
+     *             @OA\Property(property="status",  type="integer", example=500),
+     *             @OA\Property(property="message", type="string",  example="伺服器錯誤，請稍後再試"),
+     *             @OA\Property(property="errors",  type="string",  nullable=true, example=null)
+     *         )
+     *     )
+     * )
+     */
+
+class ShortUrl {}

--- a/database/migrations/2025_08_11_221831_create_short_urls_table.php
+++ b/database/migrations/2025_08_11_221831_create_short_urls_table.php
@@ -1,0 +1,35 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * 建立 short_urls 資料表
+     */
+    public function up(): void
+    {
+        Schema::create('short_urls', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('user_id')
+                ->constrained()
+                ->cascadeOnDelete()
+                ->comment('建立此短網址的使用者 ID');
+            $table->text('original_url')->comment('原始網址');
+            $table->string('short_code', 32)->unique()->comment('短網址(唯一值)');
+            $table->unsignedBigInteger('click_count')->default(0)->comment('累積點擊次數(定期由 redis 回寫)');
+            $table->timestamp('expired_at')->nullable()->index()->comment('到期時間(逾期及失效)');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('short_urls');
+    }
+};

--- a/routes/api.php
+++ b/routes/api.php
@@ -3,6 +3,7 @@
 use App\Http\Controllers\Api\UserController;
 use App\Http\Controllers\Api\PostController;
 use App\Http\Controllers\Api\CommentController;
+use App\Http\Controllers\Api\ShortUrlController;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Route;
 
@@ -47,5 +48,15 @@ Route::middleware('auth:api')->group(function () {
         Route::post('/{post}/comments', [CommentController::class, 'store']);
         // 修改留言
         Route::PUT('/{post}/comments/{comment}', [CommentController::class, 'update']);
+    });
+
+    // 短網址
+    Route::prefix('short-urls')->group(function () {
+        // 取得我的短網址清單
+        Route::get('/', [ShortUrlController::class, 'index']);
+        // 建立短網址(可自訂 short_code)
+        Route::post('/', [ShortUrlController::class, 'store']);
+        // 刪除(只能刪除自己的)
+        Route::delete('/{id}', [ShortUrlController::class, 'destroy']);
     });
 });


### PR DESCRIPTION
- 新增 `ShortUrlController`，提供建立短網址 API
- 建立 `StoreShortUrlRequest`，驗證 original_url / short_code / expired_at
- 新增 `ShortUrlResource`，統一短網址回傳格式
- 新增 `ShortUrlService`，處理短碼產生、保留字檢查、Redis 快取
- 新增 `ShortUrlRepository`，封裝資料庫存取邏輯
- 新增 `ShortUrl` Model 與對應 migration `short_urls` 資料表
- 更新 `api.php` routes，加入短網址建立 API
- 新增 Swagger 文件 (`app/Swagger/ShortUrl.php`)：
  - 建立成功 (201)
  - 未授權 (401)
  - 驗證失敗 (422) — 含欄位驗證錯誤 / 保留字 / 短碼重複

此功能完成短網址建立流程，包含完整錯誤處理與 API 文件。