### PR TITLE
feat(short-url): 新增刪除短網址功能與 Swagger 環境自動切換

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,6 +4,9 @@ APP_KEY=
 APP_DEBUG=true
 APP_URL=http://localhost
 
+# Swagger API URL (本機測試用 http://localhost:8080, 正式環境用 http://34.224.213.213)
+API_URL=http://localhost:8080
+
 LOG_CHANNEL=stack
 LOG_DEPRECATIONS_CHANNEL=null
 LOG_LEVEL=debug

--- a/app/Policies/ShortUrlPolicy.php
+++ b/app/Policies/ShortUrlPolicy.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Policies;
+
+use App\Models\ShortUrl;
+use App\Models\User;
+use Illuminate\Auth\Access\Response;
+
+class ShortUrlPolicy
+{
+    /**
+     * 判斷使用者是否可刪除短網址
+     *
+     * @param User $user
+     * @param ShortUrl $shortUrl
+     * @return Response
+     */
+    public function delete(User $user, ShortUrl $shortUrl): Response
+    {
+        return $user->id === $shortUrl->user_id
+            ? Response::allow()
+            : Response::deny('無權限刪除該短網址');
+    }
+}

--- a/app/Providers/AuthServiceProvider.php
+++ b/app/Providers/AuthServiceProvider.php
@@ -6,8 +6,10 @@ namespace App\Providers;
 use Illuminate\Foundation\Support\Providers\AuthServiceProvider as ServiceProvider;
 use App\Models\Comment;
 use App\Models\Post;
+use App\Models\ShortUrl;
 use App\Policies\CommentPolicy;
 use App\Policies\PostPolicy;
+use App\Policies\ShortUrlPolicy;
 
 class AuthServiceProvider extends ServiceProvider
 {
@@ -19,6 +21,7 @@ class AuthServiceProvider extends ServiceProvider
     protected $policies = [
         Post::class => PostPolicy::class,
         Comment::class => CommentPolicy::class,
+        ShortUrl::class => ShortUrlPolicy::class,
     ];
 
     /**

--- a/app/Repositories/ShortUrlRepository.php
+++ b/app/Repositories/ShortUrlRepository.php
@@ -4,6 +4,7 @@ namespace App\Repositories;
 
 use App\Models\ShortUrl;
 use Illuminate\Contracts\Pagination\LengthAwarePaginator;
+use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Illuminate\Database\QueryException;
 
 class ShortUrlRepository
@@ -43,5 +44,32 @@ class ShortUrlRepository
         return ShortUrl::where('user_id', $userId)
             ->orderBy('created_at', 'desc')
             ->paginate($perPage);
+    }
+
+    /**
+     * 根據 ID 查找短網址
+     *
+     * @param int $id 短網址 ID
+     * @return ShortUrl
+     * @throws ModelNotFoundException
+     */
+    public function findById(int $id): ShortUrl
+    {
+        try {
+            return ShortUrl::findOrFail($id);
+        } catch (ModelNotFoundException $e) {
+            throw new ModelNotFoundException("找不到該短網址");
+        }
+    }
+
+    /**
+     * 刪除短網址
+     *
+     * @param ShortUrl $shortUrl
+     * @return bool
+     */
+    public function delete(ShortUrl $shortUrl): bool
+    {
+        return $shortUrl->delete();
     }
 }

--- a/app/Services/ShortUrlService.php
+++ b/app/Services/ShortUrlService.php
@@ -6,6 +6,7 @@ use App\Models\ShortUrl;
 use App\Repositories\ShortUrlRepository;
 use Illuminate\Contracts\Pagination\LengthAwarePaginator;
 use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Gate;
 use Illuminate\Support\Facades\Redis;
 use Illuminate\Support\Str;
 use Illuminate\Support\Facades\DB;
@@ -142,6 +143,25 @@ class ShortUrlService
     public function getMyShortUrls(int $userId, int $perPage = 15): LengthAwarePaginator
     {
         return $this->shortUrlRepository->getUserShortUrls($userId, $perPage);
+    }
+
+    /**
+     * 刪除短網址
+     *
+     * @param int $id 短網址 ID
+     * @return void
+     * @throws Exception
+     */
+    public function delete(int $id): void
+    {
+        $shortUrl = $this->shortUrlRepository->findById($id);
+
+        Gate::authorize('delete', $shortUrl);
+
+        $this->shortUrlRepository->delete($shortUrl);
+
+        // 清除快取
+        Cache::forget(self::CACHE_KEY_CODE_PREFIX . $shortUrl->short_code);
     }
 
     /**

--- a/app/Swagger/Base.php
+++ b/app/Swagger/Base.php
@@ -10,8 +10,8 @@ namespace App\Swagger;
  *         description="這是 API 文件",
  *     ),
  *     @OA\Server(
- *         description="主要服務器",
- *         url="http://localhost:8080"
+ *         description="API Server",
+ *         url=L5_SWAGGER_CONST_API_URL
  *     )
  * )
  * 

--- a/app/Swagger/ShortUrl.php
+++ b/app/Swagger/ShortUrl.php
@@ -193,6 +193,77 @@ namespace App\Swagger;
  *             @OA\Property(property="errors",  type="string",  nullable=true, example=null)
  *         )
  *     )
+ * ),
+ *
+ * @OA\Delete(
+ *     path="/api/short-urls/{id}",
+ *     summary="刪除短網址",
+ *     tags={"ShortUrl"},
+ *     description="已登入使用者可刪除自己建立的短網址",
+ *     security={{"bearerAuth":{}}},
+ *
+ *     @OA\Parameter(
+ *         name="id",
+ *         in="path",
+ *         description="短網址 ID",
+ *         required=true,
+ *         @OA\Schema(type="integer", example=1)
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=200,
+ *         description="短網址刪除成功",
+ *         @OA\JsonContent(
+ *             @OA\Property(property="success", type="boolean", example=true),
+ *             @OA\Property(property="status",  type="integer", example=200),
+ *             @OA\Property(property="message", type="string",  example="短網址刪除成功"),
+ *             @OA\Property(property="data",    type="null",    example=null)
+ *         )
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=401,
+ *         description="尚未授權，請登入（無效的JWT）",
+ *         @OA\JsonContent(
+ *             @OA\Property(property="success", type="boolean", example=false),
+ *             @OA\Property(property="status",  type="integer", example=401),
+ *             @OA\Property(property="message", type="string",  example="尚未授權，請登入"),
+ *             @OA\Property(property="data",    type="null",    example=null)
+ *         )
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=403,
+ *         description="無權限刪除該短網址（不是擁有者）",
+ *         @OA\JsonContent(
+ *             @OA\Property(property="success", type="boolean", example=false),
+ *             @OA\Property(property="status",  type="integer", example=403),
+ *             @OA\Property(property="message", type="string",  example="無權限刪除該短網址"),
+ *             @OA\Property(property="data",    type="null",    example=null)
+ *         )
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=404,
+ *         description="找不到該短網址",
+ *         @OA\JsonContent(
+ *             @OA\Property(property="success", type="boolean", example=false),
+ *             @OA\Property(property="status",  type="integer", example=404),
+ *             @OA\Property(property="message", type="string",  example="找不到該短網址"),
+ *             @OA\Property(property="data",    type="null",    example=null)
+ *         )
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=500,
+ *         description="系統錯誤",
+ *         @OA\JsonContent(
+ *             @OA\Property(property="success", type="boolean", example=false),
+ *             @OA\Property(property="status",  type="integer", example=500),
+ *             @OA\Property(property="message", type="string",  example="伺服器錯誤，請稍後再試"),
+ *             @OA\Property(property="data",    type="null",    example=null)
+ *         )
+ *     )
  * )
  */
 

--- a/config/l5-swagger.php
+++ b/config/l5-swagger.php
@@ -313,6 +313,7 @@ return [
          */
         'constants' => [
             'L5_SWAGGER_CONST_HOST' => env('L5_SWAGGER_CONST_HOST', 'http://my-default-host.com'),
+            'L5_SWAGGER_CONST_API_URL' => env('API_URL', 'http://localhost:8080'),
         ],
     ],
 ];


### PR DESCRIPTION
刪除短網址功能：
- 新增 ShortUrlPolicy 授權策略（僅所有者可刪除）
- 新增 ShortUrlController::destroy 方法，支援完整錯誤處理
  - 404: 找不到短網址
  - 403: 無權限刪除該短網址
  - 500: 系統錯誤
- 新增 ShortUrlService::delete 方法，包含權限檢查與快取清除
- 新增 ShortUrlRepository::findById 和 delete 方法
- 在 AuthServiceProvider 註冊 ShortUrlPolicy
- 新增 DELETE /api/short-urls/{id} Swagger 文件

Swagger 環境自動切換：
- 修改 l5-swagger 配置，新增 L5_SWAGGER_CONST_API_URL 常數
- 修改 Swagger Base.php，使用環境變數動態設定服務器 URL
- 新增 API_URL 環境變數（預設 http://localhost:8080）
- 支援本機和正式環境自動切換