### PR TITLE
feat(post): 新增使用者文章列表功能與可選驗證機制

### DIFF
--- a/app/Http/Controllers/Api/PostController.php
+++ b/app/Http/Controllers/Api/PostController.php
@@ -4,8 +4,10 @@ namespace App\Http\Controllers\Api;
 
 use App\Http\Controllers\Controller;
 use App\Http\Requests\StorePostRequest;
+use App\Http\Requests\GetUserPostsRequest;
 use App\Http\Resources\PostResource;
 use App\Services\PostService;
+use Illuminate\Support\Facades\Auth;
 use Exception;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Illuminate\Auth\Access\AuthorizationException;
@@ -89,6 +91,53 @@ class PostController extends Controller
                 'success' => false,
                 'status' => $e->getCode() ?: Response::HTTP_INTERNAL_SERVER_ERROR,
                 'message' => $e->getMessage(),
+                'data' => null
+            ], $e->getCode() ?: Response::HTTP_INTERNAL_SERVER_ERROR);
+        }
+    }
+
+    /**
+     * 取得指定使用者的文章列表（分頁）
+     *
+     * @param GetUserPostsRequest $request 驗證後的請求資料
+     * @param int $userId 使用者 ID（路由參數）
+     * @return JsonResponse
+     */
+    public function getUserPosts(GetUserPostsRequest $request, int $userId): JsonResponse
+    {
+        try {
+            $validated = $request->validated();
+            $status = $validated['status'] ?? 2; // 預設顯示已發佈的文章
+            $perPage = $validated['per_page'] ?? 15; // 預設每頁 15 筆
+
+            $posts = $this->postService->getUserPosts($userId, $status, $perPage);
+
+            return response()->json([
+                'success' => true,
+                'status' => Response::HTTP_OK,
+                'message' => '文章列表取得成功',
+                'data' => [
+                    'posts' => PostResource::collection($posts->items()),
+                    'pagination' => [
+                        'current_page' => $posts->currentPage(),
+                        'per_page' => $posts->perPage(),
+                        'total' => $posts->total(),
+                        'last_page' => $posts->lastPage(),
+                    ],
+                ],
+            ], Response::HTTP_OK);
+        } catch (AuthorizationException $e) {
+            return response()->json([
+                'success' => false,
+                'status' => Response::HTTP_FORBIDDEN,
+                'message' => $e->getMessage(),
+                'data' => null
+            ], Response::HTTP_FORBIDDEN);
+        } catch (Exception $e) {
+            return response()->json([
+                'success' => false,
+                'status' => $e->getCode() ?: Response::HTTP_INTERNAL_SERVER_ERROR,
+                'message' => '伺服器錯誤，請稍後再試',
                 'data' => null
             ], $e->getCode() ?: Response::HTTP_INTERNAL_SERVER_ERROR);
         }

--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -64,5 +64,6 @@ class Kernel extends HttpKernel
         'signed' => \App\Http\Middleware\ValidateSignature::class,
         'throttle' => \Illuminate\Routing\Middleware\ThrottleRequests::class,
         'verified' => \Illuminate\Auth\Middleware\EnsureEmailIsVerified::class,
+        'optional.auth' => \App\Http\Middleware\OptionalAuth::class,
     ];
 }

--- a/app/Http/Middleware/OptionalAuth.php
+++ b/app/Http/Middleware/OptionalAuth.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Tymon\JWTAuth\Facades\JWTAuth;
+use Tymon\JWTAuth\Exceptions\JWTException;
+
+/**
+ * 可選的身份驗證中間件
+ *
+ * 嘗試驗證 JWT token，但不強制要求
+ * 如果有有效的 token，設定當前使用者；否則繼續執行
+ */
+class OptionalAuth
+{
+    /**
+     * Handle an incoming request.
+     *
+     * @param  \Closure(\Illuminate\Http\Request): (\Symfony\Component\HttpFoundation\Response)  $next
+     */
+    public function handle(Request $request, Closure $next): Response
+    {
+        try {
+            // 嘗試從請求中解析 JWT token
+            if ($token = $request->bearerToken()) {
+                // 嘗試驗證並取得使用者
+                $user = JWTAuth::setToken($token)->authenticate();
+
+                // 如果成功，設定當前使用者
+                if ($user) {
+                    auth()->setUser($user);
+                }
+            }
+        } catch (JWTException $e) {
+            // Token 無效或過期，不做任何事，繼續執行
+            // 這樣未登入的使用者也能訪問
+        }
+
+        return $next($request);
+    }
+}

--- a/app/Http/Requests/GetUserPostsRequest.php
+++ b/app/Http/Requests/GetUserPostsRequest.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class GetUserPostsRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * 設定驗證規則
+     *
+     * @return array<string, \Illuminate\Contracts\Validation\ValidationRule|array<mixed>|string>
+     */
+    public function rules(): array
+    {
+        return [
+            'status' => 'nullable|integer|in:1,2,3', // 1:草稿, 2:發布, 3:隱藏
+            'per_page' => 'nullable|integer|min:1|max:100', // 每頁筆數，最多 100
+            'page' => 'nullable|integer|min:1', // 頁碼
+        ];
+    }
+
+    /**
+     * 自訂錯誤訊息
+     *
+     * @return array<string, string>
+     */
+    public function messages(): array
+    {
+        return [
+            'status.integer' => '狀態必須為整數',
+            'status.in' => '狀態僅允許 1(草稿)、2(發布)、3(隱藏)',
+            'per_page.integer' => '每頁筆數必須為整數',
+            'per_page.min' => '每頁筆數最少為 1',
+            'per_page.max' => '每頁筆數最多為 100',
+            'page.integer' => '頁碼必須為整數',
+            'page.min' => '頁碼最少為 1',
+        ];
+    }
+}

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -58,11 +58,21 @@ class User extends Authenticatable implements JWTSubject
 
     /**
      * 一個使用者有多個留言
-     * 
+     *
      * @return \Illuminate\Database\Eloquent\Relations\HasMany
      */
     public function comments()
     {
         return $this->hasMany(Comment::class);
+    }
+
+    /**
+     * 一個使用者有多篇文章
+     *
+     * @return \Illuminate\Database\Eloquent\Relations\HasMany
+     */
+    public function posts()
+    {
+        return $this->hasMany(Post::class);
     }
 }

--- a/app/Policies/PostPolicy.php
+++ b/app/Policies/PostPolicy.php
@@ -67,4 +67,29 @@ class PostPolicy
     {
         //
     }
+
+    /**
+     * 判斷使用者是否可以查看特定使用者的特定狀態文章
+     * 草稿(1) 和隱藏(3) 只有本人可以查看
+     *
+     * @param User|null $user 當前登入使用者（可能為 null，未登入）
+     * @param int $targetUserId 目標使用者 ID
+     * @param int $status 文章狀態 (1:草稿, 2:發布, 3:隱藏)
+     * @return bool
+     */
+    public function viewUserPosts(?User $user, int $targetUserId, int $status): bool
+    {
+        // 如果查看已發佈的文章(status=2)，任何人都可以看
+        if ($status === 2) {
+            return true;
+        }
+
+        // 如果查看草稿(1) 或隱藏(3)，只有本人可以看
+        if ($status === 1 || $status === 3) {
+            return $user && $user->id === $targetUserId;
+        }
+
+        // 其他情況不允許
+        return false;
+    }
 }

--- a/app/Repositories/PostRepository.php
+++ b/app/Repositories/PostRepository.php
@@ -43,13 +43,30 @@ class PostRepository
 
     /**
      * 更新文章
-     * 
-     * @param Post $post 
-     * @param array $data 
+     *
+     * @param Post $post
+     * @param array $data
      * @return bool
      */
     public function updatePost(Post $post, array $data): bool
     {
         return $post->update($data);
+    }
+
+    /**
+     * 取得使用者的文章列表（分頁）
+     *
+     * @param int $userId 使用者 ID
+     * @param int $status 文章狀態 (1:草稿, 2:發布, 3:隱藏)
+     * @param int $perPage 每頁筆數，預設 15
+     * @return \Illuminate\Contracts\Pagination\LengthAwarePaginator
+     */
+    public function getUserPosts(int $userId, int $status, int $perPage = 15)
+    {
+        return Post::where('user_id', $userId)
+            ->where('status', $status)
+            ->with('user')
+            ->orderBy('created_at', 'desc')
+            ->paginate($perPage);
     }
 }

--- a/app/Services/PostService.php
+++ b/app/Services/PostService.php
@@ -65,4 +65,24 @@ class PostService
 
         return $post->load('user');
     }
+
+    /**
+     * 取得使用者的文章列表（分頁）
+     *
+     * @param int $userId 使用者 ID
+     * @param int $status 文章狀態 (1:草稿, 2:發布, 3:隱藏)
+     * @param int $perPage 每頁筆數，預設 15
+     * @return \Illuminate\Contracts\Pagination\LengthAwarePaginator
+     * @throws AuthorizationException 當沒有權限查看指定狀態的文章時
+     */
+    public function getUserPosts(int $userId, int $status, int $perPage = 15)
+    {
+        // 使用 Policy 檢查權限
+        // 草稿(1) 和隱藏(3) 只有本人可以查看
+        if (Gate::denies('viewUserPosts', [Post::class, $userId, $status])) {
+            throw new AuthorizationException('你沒有權限查看此內容');
+        }
+
+        return $this->postRepository->getUserPosts($userId, $status, $perPage);
+    }
 }

--- a/app/Swagger/Post.php
+++ b/app/Swagger/Post.php
@@ -1,4 +1,4 @@
-<?php 
+<?php
 
 namespace App\Swagger;
 

--- a/app/Swagger/User.php
+++ b/app/Swagger/User.php
@@ -83,7 +83,7 @@ namespace App\Swagger;
  *     description="使用者登出，JWT token 失效處理",
  *     security={{"bearerAuth":{}}},
  *     operationId="logoutUser",
- *     
+ *
  *     @OA\Response(
  *         response=200,
  *         description="登出成功",
@@ -91,7 +91,7 @@ namespace App\Swagger;
  *             @OA\Property(property="success", type="boolean", example=true),
  *             @OA\Property(property="status", type="integer", example=200),
  *             @OA\Property(property="message", type="string", example="登出成功"),
- *             @OA\Property(property="data", type="string", example=null, nullable=true) 
+ *             @OA\Property(property="data", type="string", example=null, nullable=true)
  *         )
  *     ),
  *     @OA\Response(
@@ -102,6 +102,131 @@ namespace App\Swagger;
  *             @OA\Property(property="status", type="integer", example=500),
  *             @OA\Property(property="message", type="string", example="登出失敗"),
  *             @OA\Property(property="data", type="string", example=null, nullable=true)
+ *         )
+ *     )
+ * ),
+ *
+ * @OA\Get(
+ *     path="/api/user/{user}/posts",
+ *     summary="取得使用者的文章列表",
+ *     tags={"User"},
+ *     description="取得指定使用者的文章列表（分頁）。預設顯示已發佈文章（任何人可看），草稿和隱藏文章只有本人登入後可看。",
+ *     operationId="getUserPosts",
+ *     security={{}, {"bearerAuth":{}}},
+ *
+ *     @OA\Parameter(
+ *         name="user",
+ *         in="path",
+ *         description="使用者 ID",
+ *         required=true,
+ *         @OA\Schema(type="integer", example=1)
+ *     ),
+ *     @OA\Parameter(
+ *         name="status",
+ *         in="query",
+ *         description="文章狀態 (1:草稿, 2:發布, 3:隱藏)，預設為 2",
+ *         required=false,
+ *         @OA\Schema(type="integer", enum={1, 2, 3}, example=2)
+ *     ),
+ *     @OA\Parameter(
+ *         name="per_page",
+ *         in="query",
+ *         description="每頁筆數，預設 15，最多 100",
+ *         required=false,
+ *         @OA\Schema(type="integer", example=15)
+ *     ),
+ *     @OA\Parameter(
+ *         name="page",
+ *         in="query",
+ *         description="頁碼，預設 1",
+ *         required=false,
+ *         @OA\Schema(type="integer", example=1)
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=200,
+ *         description="文章列表取得成功",
+ *         @OA\JsonContent(
+ *             @OA\Property(property="success", type="boolean", example=true),
+ *             @OA\Property(property="status", type="integer", example=200),
+ *             @OA\Property(property="message", type="string", example="文章列表取得成功"),
+ *             @OA\Property(
+ *                 property="data",
+ *                 type="object",
+ *                 @OA\Property(
+ *                     property="posts",
+ *                     type="array",
+ *                     @OA\Items(
+ *                         type="object",
+ *                         @OA\Property(property="id", type="integer", example=1),
+ *                         @OA\Property(property="title", type="string", example="我的第一篇文章"),
+ *                         @OA\Property(property="content", type="string", example="這是文章內容..."),
+ *                         @OA\Property(property="status", type="integer", example=2, description="1:草稿, 2:發布, 3:隱藏"),
+ *                         @OA\Property(
+ *                             property="user",
+ *                             type="object",
+ *                             @OA\Property(property="id", type="integer", example=1),
+ *                             @OA\Property(property="name", type="string", example="張三")
+ *                         ),
+ *                         @OA\Property(property="created_at", type="string", format="date-time", example="2025-08-12 00:55:29"),
+ *                         @OA\Property(property="updated_at", type="string", format="date-time", example="2025-08-12 00:55:29")
+ *                     )
+ *                 ),
+ *                 @OA\Property(
+ *                     property="pagination",
+ *                     type="object",
+ *                     @OA\Property(property="current_page", type="integer", example=1),
+ *                     @OA\Property(property="per_page", type="integer", example=15),
+ *                     @OA\Property(property="total", type="integer", example=50),
+ *                     @OA\Property(property="last_page", type="integer", example=4)
+ *                 )
+ *             )
+ *         )
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=403,
+ *         description="無權限查看此內容（嘗試查看他人的草稿或隱藏文章）",
+ *         @OA\JsonContent(
+ *             @OA\Property(property="success", type="boolean", example=false),
+ *             @OA\Property(property="status", type="integer", example=403),
+ *             @OA\Property(property="message", type="string", example="你沒有權限查看此內容"),
+ *             @OA\Property(property="data", type="null", example=null)
+ *         )
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=422,
+ *         description="驗證失敗",
+ *         @OA\JsonContent(
+ *             @OA\Property(property="success", type="boolean", example=false),
+ *             @OA\Property(property="status", type="integer", example=422),
+ *             @OA\Property(property="message", type="string", example="驗證失敗"),
+ *             @OA\Property(
+ *                 property="errors",
+ *                 type="object",
+ *                 @OA\Property(
+ *                     property="status",
+ *                     type="array",
+ *                     @OA\Items(type="string", example="狀態僅允許 1(草稿)、2(發布)、3(隱藏)")
+ *                 ),
+ *                 @OA\Property(
+ *                     property="per_page",
+ *                     type="array",
+ *                     @OA\Items(type="string", example="每頁筆數最多為 100")
+ *                 )
+ *             )
+ *         )
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=500,
+ *         description="伺服器錯誤",
+ *         @OA\JsonContent(
+ *             @OA\Property(property="success", type="boolean", example=false),
+ *             @OA\Property(property="status", type="integer", example=500),
+ *             @OA\Property(property="message", type="string", example="伺服器錯誤，請稍後再試"),
+ *             @OA\Property(property="data", type="null", example=null)
  *         )
  *     )
  * )

--- a/routes/api.php
+++ b/routes/api.php
@@ -29,6 +29,10 @@ Route::prefix('user')->group(function () {
     // 使用者登入
     Route::post('/login', [UserController::class, 'login']);
 
+    // 取得使用者的文章列表（公開，任何人可訪問已發佈文章，草稿和隱藏需要本人登入）
+    Route::get('/{user}/posts', [PostController::class, 'getUserPosts'])
+        ->middleware('optional.auth');
+
     // 使用者登出
     Route::middleware('auth:api')->group(function () {
         Route::post('/logout', [UserController::class, 'logout']);


### PR DESCRIPTION
新增 GET /api/user/{user}/posts API，支援分頁查詢使用者的文章列表，
並實作權限控制機制（已發佈文章公開，草稿和隱藏文章僅本人可見）。

主要變更：
- 新增 OptionalAuth middleware 支援可選驗證（未登入可訪問，已登入可識別）
- 新增 GetUserPostsRequest 驗證 query 參數（status, per_page, page）
- Repository: 新增 getUserPosts() 查詢方法，支援狀態過濾與分頁
- Service: 整合 Policy 權限檢查，草稿(1)和隱藏(3)僅本人可查看
- Policy: 新增 viewUserPosts() 權限判斷方法
- Controller: 新增 getUserPosts() 處理文章列表請求
- Model: User 新增 posts() 關聯方法
- Routes: 註冊 GET /api/user/{user}/posts 路由並套用 optional.auth
- Swagger: 新增完整的 API 文檔（含分頁、權限說明）