### PR TITLE
feat(post): 新增刪除文章與更新文章狀態功能

### DIFF
--- a/app/Http/Controllers/Api/PostController.php
+++ b/app/Http/Controllers/Api/PostController.php
@@ -5,6 +5,7 @@ namespace App\Http\Controllers\Api;
 use App\Http\Controllers\Controller;
 use App\Http\Requests\StorePostRequest;
 use App\Http\Requests\GetUserPostsRequest;
+use App\Http\Requests\UpdatePostStatusRequest;
 use App\Http\Resources\PostResource;
 use App\Services\PostService;
 use Illuminate\Support\Facades\Auth;
@@ -138,6 +139,90 @@ class PostController extends Controller
                 'success' => false,
                 'status' => $e->getCode() ?: Response::HTTP_INTERNAL_SERVER_ERROR,
                 'message' => '伺服器錯誤，請稍後再試',
+                'data' => null
+            ], $e->getCode() ?: Response::HTTP_INTERNAL_SERVER_ERROR);
+        }
+    }
+
+    /**
+     * 刪除文章
+     *
+     * @param int $id 文章 ID（路由參數）
+     * @return JsonResponse
+     */
+    public function destroy(int $id): JsonResponse
+    {
+        try {
+            $this->postService->deletePost($id);
+
+            return response()->json([
+                'success' => true,
+                'status' => Response::HTTP_OK,
+                'message' => '文章刪除成功',
+                'data' => null
+            ], Response::HTTP_OK);
+        } catch (ModelNotFoundException $e) {
+            return response()->json([
+                'success' => false,
+                'status' => Response::HTTP_NOT_FOUND,
+                'message' => $e->getMessage(),
+                'data' => null
+            ], Response::HTTP_NOT_FOUND);
+        } catch (AuthorizationException $e) {
+            return response()->json([
+                'success' => false,
+                'status' => Response::HTTP_FORBIDDEN,
+                'message' => $e->getMessage(),
+                'data' => null
+            ], Response::HTTP_FORBIDDEN);
+        } catch (Exception $e) {
+            return response()->json([
+                'success' => false,
+                'status' => $e->getCode() ?: Response::HTTP_INTERNAL_SERVER_ERROR,
+                'message' => '伺服器錯誤，請稍後再試',
+                'data' => null
+            ], $e->getCode() ?: Response::HTTP_INTERNAL_SERVER_ERROR);
+        }
+    }
+
+    /**
+     * 更新文章狀態
+     *
+     * @param UpdatePostStatusRequest $request 驗證後的請求資料
+     * @param int $id 文章 ID（路由參數）
+     * @return JsonResponse
+     */
+    public function updateStatus(UpdatePostStatusRequest $request, int $id): JsonResponse
+    {
+        try {
+            $validated = $request->validated();
+            $post = $this->postService->updatePostStatus($id, $validated['status']);
+
+            return response()->json([
+                'success' => true,
+                'status' => Response::HTTP_OK,
+                'message' => '文章狀態更新成功',
+                'data' => new PostResource($post)
+            ], Response::HTTP_OK);
+        } catch (ModelNotFoundException $e) {
+            return response()->json([
+                'success' => false,
+                'status' => Response::HTTP_NOT_FOUND,
+                'message' => $e->getMessage(),
+                'data' => null
+            ], Response::HTTP_NOT_FOUND);
+        } catch (AuthorizationException $e) {
+            return response()->json([
+                'success' => false,
+                'status' => Response::HTTP_FORBIDDEN,
+                'message' => $e->getMessage(),
+                'data' => null
+            ], Response::HTTP_FORBIDDEN);
+        } catch (Exception $e) {
+            return response()->json([
+                'success' => false,
+                'status' => $e->getCode() ?: Response::HTTP_INTERNAL_SERVER_ERROR,
+                'message' => $e->getMessage(),
                 'data' => null
             ], $e->getCode() ?: Response::HTTP_INTERNAL_SERVER_ERROR);
         }

--- a/app/Http/Requests/UpdatePostStatusRequest.php
+++ b/app/Http/Requests/UpdatePostStatusRequest.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class UpdatePostStatusRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * 設定驗證規則
+     *
+     * @return array<string, \Illuminate\Contracts\Validation\ValidationRule|array<mixed>|string>
+     */
+    public function rules(): array
+    {
+        return [
+            'status' => 'required|integer|in:1,2,3', // 1:草稿, 2:發布, 3:隱藏
+        ];
+    }
+
+    /**
+     * 自訂錯誤訊息
+     *
+     * @return array<string, string>
+     */
+    public function messages(): array
+    {
+        return [
+            'status.required' => '狀態為必填',
+            'status.integer' => '狀態必須為整數',
+            'status.in' => '狀態僅允許 1(草稿)、2(發布)、3(隱藏)',
+        ];
+    }
+}

--- a/app/Policies/PostPolicy.php
+++ b/app/Policies/PostPolicy.php
@@ -45,11 +45,16 @@ class PostPolicy
     }
 
     /**
-     * Determine whether the user can delete the model.
+     * 判斷使用者是否可以刪除文章
+     * 只有文章作者本人可以刪除
+     *
+     * @param User $user
+     * @param Post $post
+     * @return bool
      */
     public function delete(User $user, Post $post): bool
     {
-        //
+        return $user->id === $post->user_id;
     }
 
     /**

--- a/app/Repositories/PostRepository.php
+++ b/app/Repositories/PostRepository.php
@@ -69,4 +69,27 @@ class PostRepository
             ->orderBy('created_at', 'desc')
             ->paginate($perPage);
     }
+
+    /**
+     * 刪除文章
+     *
+     * @param Post $post
+     * @return bool|null
+     */
+    public function deletePost(Post $post): ?bool
+    {
+        return $post->delete();
+    }
+
+    /**
+     * 更新文章狀態
+     *
+     * @param Post $post
+     * @param int $status 新的狀態 (1:草稿, 2:發布, 3:隱藏)
+     * @return bool
+     */
+    public function updatePostStatus(Post $post, int $status): bool
+    {
+        return $post->update(['status' => $status]);
+    }
 }

--- a/app/Swagger/Post.php
+++ b/app/Swagger/Post.php
@@ -172,6 +172,194 @@ namespace App\Swagger;
  *             @OA\Property(property="data", type="string", example=null)
  *         )
  *     )
+ * ),
+ *
+ * @OA\Delete(
+ *     path="/api/posts/{post}",
+ *     summary="刪除文章",
+ *     tags={"Post"},
+ *     description="已登入使用者可刪除自己建立的文章",
+ *     operationId="deletePost",
+ *     security={{"bearerAuth":{}}},
+ *
+ *     @OA\Parameter(
+ *         name="post",
+ *         in="path",
+ *         description="文章 ID",
+ *         required=true,
+ *         @OA\Schema(type="integer", example=1)
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=200,
+ *         description="文章刪除成功",
+ *         @OA\JsonContent(
+ *             @OA\Property(property="success", type="boolean", example=true),
+ *             @OA\Property(property="status", type="integer", example=200),
+ *             @OA\Property(property="message", type="string", example="文章刪除成功"),
+ *             @OA\Property(property="data", type="string", nullable=true, example=null)
+ *         )
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=401,
+ *         description="尚未授權，請登入",
+ *         @OA\JsonContent(
+ *             @OA\Property(property="success", type="boolean", example=false),
+ *             @OA\Property(property="status", type="integer", example=401),
+ *             @OA\Property(property="message", type="string", example="尚未授權，請登入"),
+ *             @OA\Property(property="data", type="string", nullable=true, example=null)
+ *         )
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=403,
+ *         description="無權限刪除文章",
+ *         @OA\JsonContent(
+ *             @OA\Property(property="success", type="boolean", example=false),
+ *             @OA\Property(property="status", type="integer", example=403),
+ *             @OA\Property(property="message", type="string", example="你沒有權限刪除該文章"),
+ *             @OA\Property(property="data", type="string", nullable=true, example=null)
+ *         )
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=404,
+ *         description="找不到該文章",
+ *         @OA\JsonContent(
+ *             @OA\Property(property="success", type="boolean", example=false),
+ *             @OA\Property(property="status", type="integer", example=404),
+ *             @OA\Property(property="message", type="string", example="找不到該文章"),
+ *             @OA\Property(property="data", type="string", nullable=true, example=null)
+ *         )
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=500,
+ *         description="伺服器錯誤",
+ *         @OA\JsonContent(
+ *             @OA\Property(property="success", type="boolean", example=false),
+ *             @OA\Property(property="status", type="integer", example=500),
+ *             @OA\Property(property="message", type="string", example="伺服器錯誤，請稍後再試"),
+ *             @OA\Property(property="data", type="string", nullable=true, example=null)
+ *         )
+ *     )
+ * ),
+ *
+ * @OA\Patch(
+ *     path="/api/posts/{post}/status",
+ *     summary="更新文章狀態",
+ *     tags={"Post"},
+ *     description="已登入使用者可更新自己建立的文章狀態。狀態轉換規則：草稿(1)→發布(2)、發布(2)→隱藏(3)、隱藏(3)→發布(2)。不可將已發布或隱藏的文章改回草稿。",
+ *     operationId="updatePostStatus",
+ *     security={{"bearerAuth":{}}},
+ *
+ *     @OA\Parameter(
+ *         name="post",
+ *         in="path",
+ *         description="文章 ID",
+ *         required=true,
+ *         @OA\Schema(type="integer", example=1)
+ *     ),
+ *
+ *     @OA\RequestBody(
+ *         required=true,
+ *         @OA\JsonContent(
+ *             required={"status"},
+ *             @OA\Property(
+ *                 property="status",
+ *                 type="integer",
+ *                 description="文章狀態 (1:草稿, 2:發布, 3:隱藏)",
+ *                 enum={1, 2, 3},
+ *                 example=2
+ *             )
+ *         )
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=200,
+ *         description="文章狀態更新成功",
+ *         @OA\JsonContent(ref="#/components/schemas/PostResource")
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=401,
+ *         description="尚未授權，請登入",
+ *         @OA\JsonContent(
+ *             @OA\Property(property="success", type="boolean", example=false),
+ *             @OA\Property(property="status", type="integer", example=401),
+ *             @OA\Property(property="message", type="string", example="尚未授權，請登入"),
+ *             @OA\Property(property="data", type="string", nullable=true, example=null)
+ *         )
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=403,
+ *         description="無權限修改文章",
+ *         @OA\JsonContent(
+ *             @OA\Property(property="success", type="boolean", example=false),
+ *             @OA\Property(property="status", type="integer", example=403),
+ *             @OA\Property(property="message", type="string", example="你沒有權限修改該文章"),
+ *             @OA\Property(property="data", type="string", nullable=true, example=null)
+ *         )
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=404,
+ *         description="找不到該文章",
+ *         @OA\JsonContent(
+ *             @OA\Property(property="success", type="boolean", example=false),
+ *             @OA\Property(property="status", type="integer", example=404),
+ *             @OA\Property(property="message", type="string", example="找不到該文章"),
+ *             @OA\Property(property="data", type="string", nullable=true, example=null)
+ *         )
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=422,
+ *         description="驗證失敗或狀態轉換不合法",
+ *         @OA\JsonContent(
+ *             oneOf={
+ *                 @OA\Schema(
+ *                     @OA\Property(property="success", type="boolean", example=false),
+ *                     @OA\Property(property="status", type="integer", example=422),
+ *                     @OA\Property(property="message", type="string", example="驗證失敗"),
+ *                     @OA\Property(
+ *                         property="errors",
+ *                         type="object",
+ *                         @OA\Property(
+ *                             property="status",
+ *                             type="array",
+ *                             @OA\Items(type="string", example="狀態僅允許 1(草稿)、2(發布)、3(隱藏)")
+ *                         )
+ *                     )
+ *                 ),
+ *                 @OA\Schema(
+ *                     @OA\Property(property="success", type="boolean", example=false),
+ *                     @OA\Property(property="status", type="integer", example=422),
+ *                     @OA\Property(property="message", type="string", example="不允許將文章從「發布」狀態變更為「草稿」狀態"),
+ *                     @OA\Property(property="data", type="string", nullable=true, example=null)
+ *                 ),
+ *                 @OA\Schema(
+ *                     @OA\Property(property="success", type="boolean", example=false),
+ *                     @OA\Property(property="status", type="integer", example=422),
+ *                     @OA\Property(property="message", type="string", example="新狀態與目前狀態相同"),
+ *                     @OA\Property(property="data", type="string", nullable=true, example=null)
+ *                 )
+ *             }
+ *         )
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=500,
+ *         description="伺服器錯誤",
+ *         @OA\JsonContent(
+ *             @OA\Property(property="success", type="boolean", example=false),
+ *             @OA\Property(property="status", type="integer", example=500),
+ *             @OA\Property(property="message", type="string", example="伺服器錯誤，請稍後再試"),
+ *             @OA\Property(property="data", type="string", nullable=true, example=null)
+ *         )
+ *     )
  * )
  */
 

--- a/routes/api.php
+++ b/routes/api.php
@@ -47,6 +47,10 @@ Route::middleware('auth:api')->group(function () {
         Route::post('/', [PostController::class, 'store']);
         // 更新文章
         Route::PUT('/{post}', [PostController::class, 'update']);
+        // 刪除文章
+        Route::delete('/{post}', [PostController::class, 'destroy']);
+        // 更新文章狀態
+        Route::patch('/{post}/status', [PostController::class, 'updateStatus']);
 
         // 對文章新增留言
         Route::post('/{post}/comments', [CommentController::class, 'store']);


### PR DESCRIPTION
- 新增刪除文章 API (DELETE /api/posts/{post})
  * 實作 PostController::destroy() 方法處理刪除請求
  * 新增 PostPolicy::delete() 權限檢查，僅作者可刪除
  * 實作 PostService::deletePost() 處理刪除邏輯
  * 實作 PostRepository::deletePost() 執行資料庫刪除

- 新增更新文章狀態 API (PATCH /api/posts/{post}/status)
  * 實作 PostController::updateStatus() 方法處理狀態更新
  * 建立 UpdatePostStatusRequest 驗證狀態值 (1:草稿, 2:發布, 3:隱藏)
  * 實作 PostService::updatePostStatus() 處理狀態更新邏輯
  * 新增狀態轉換驗證：草稿→發布、發布→隱藏、隱藏→發布
  * 禁止將已發布或隱藏的文章改回草稿狀態
  * 實作 PostRepository::updatePostStatus() 執行狀態更新
  * 支援 UI 快速切換狀態，無需傳送完整文章資料

- 新增完整 Swagger API 文檔
  * 刪除文章 API 文檔 (含權限與錯誤處理說明)
  * 更新文章狀態 API 文檔 (含狀態轉換規則與驗證錯誤範例)

- 更新路由配置
  * routes/api.php 新增兩個受保護路由至 auth:api 中介層