### PR TITLE
feat(auth): 新增角色權限系統與使用者角色管理機制

### DIFF
--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -65,5 +65,6 @@ class Kernel extends HttpKernel
         'throttle' => \Illuminate\Routing\Middleware\ThrottleRequests::class,
         'verified' => \Illuminate\Auth\Middleware\EnsureEmailIsVerified::class,
         'optional.auth' => \App\Http\Middleware\OptionalAuth::class,
+        'admin' => \App\Http\Middleware\AdminMiddleware::class,
     ];
 }

--- a/app/Http/Middleware/AdminMiddleware.php
+++ b/app/Http/Middleware/AdminMiddleware.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+class AdminMiddleware
+{
+    /**
+     * Handle an incoming request.
+     *
+     * @param  \Closure(\Illuminate\Http\Request): (\Symfony\Component\HttpFoundation\Response)  $next
+     */
+    public function handle(Request $request, Closure $next): Response
+    {
+        // 檢查使用者是否已登入
+        if (!auth('api')->check()) {
+            return response()->json([
+                'success' => false,
+                'status' => 401,
+                'message' => '請先登入',
+                'data' => null,
+            ], 401);
+        }
+
+        // 檢查使用者是否為管理者
+        $user = auth('api')->user();
+
+        if (!$user->isAdmin()) {
+            return response()->json([
+                'success' => false,
+                'status' => 403,
+                'message' => '權限不足，僅限管理者使用',
+                'data' => null,
+            ], 403);
+        }
+
+        return $next($request);
+    }
+}

--- a/app/Models/Role.php
+++ b/app/Models/Role.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class Role extends Model
+{
+    use HasFactory;
+
+    /**
+     * 角色常數
+     */
+    const ADMIN = 'admin';  // 管理者
+    const USER = 'user';    // 一般使用者
+
+    /**
+     * 可批量賦值的屬性
+     */
+    protected $fillable = [
+        'name',
+        'display_name',
+        'description',
+    ];
+
+    /**
+     * 關聯：一個角色有多個使用者
+     *
+     * @return \Illuminate\Database\Eloquent\Relations\HasMany
+     */
+    public function users()
+    {
+        return $this->hasMany(User::class);
+    }
+}

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -35,7 +35,8 @@ class User extends Authenticatable implements JWTSubject
         'name',
         'email',
         'password',
-        'phone'
+        'phone',
+        'role_id'
     ];
 
     /**
@@ -74,5 +75,46 @@ class User extends Authenticatable implements JWTSubject
     public function posts()
     {
         return $this->hasMany(Post::class);
+    }
+
+    /**
+     * 一個使用者屬於一個角色
+     *
+     * @return \Illuminate\Database\Eloquent\Relations\BelongsTo
+     */
+    public function role()
+    {
+        return $this->belongsTo(Role::class);
+    }
+
+    /**
+     * 檢查使用者是否為管理者
+     *
+     * @return bool
+     */
+    public function isAdmin(): bool
+    {
+        return $this->role && $this->role->name === Role::ADMIN;
+    }
+
+    /**
+     * 檢查使用者是否為一般使用者
+     *
+     * @return bool
+     */
+    public function isUser(): bool
+    {
+        return $this->role && $this->role->name === Role::USER;
+    }
+
+    /**
+     * 檢查使用者是否有指定角色
+     *
+     * @param string $roleName
+     * @return bool
+     */
+    public function hasRole(string $roleName): bool
+    {
+        return $this->role && $this->role->name === $roleName;
     }
 }

--- a/app/Repositories/RoleRepository.php
+++ b/app/Repositories/RoleRepository.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace App\Repositories;
+
+use App\Models\Role;
+
+class RoleRepository
+{
+    /**
+     * 根據角色名稱查詢角色
+     *
+     * @param string $name
+     * @return Role|null
+     */
+    public function findByName(string $name): ?Role
+    {
+        return Role::where('name', $name)->first();
+    }
+
+    /**
+     * 取得所有角色
+     *
+     * @return \Illuminate\Database\Eloquent\Collection
+     */
+    public function getAllRoles()
+    {
+        return Role::all();
+    }
+
+    /**
+     * 建立角色
+     *
+     * @param array $data
+     * @return Role
+     */
+    public function createRole(array $data): Role
+    {
+        return Role::create($data);
+    }
+}

--- a/app/Repositories/UserRepository.php
+++ b/app/Repositories/UserRepository.php
@@ -11,18 +11,19 @@ class UserRepository
 {
     /**
      * 建立使用者資料
-     * 
-     * @param array{name: string, email: string, password: string, phone?: string|null} $data
+     *
+     * @param array{name: string, email: string, password: string, phone?: string|null, role_id?: int|null} $data
      * @return User
-     * @throws Exception 建立失敗時拋出例外 
+     * @throws Exception 建立失敗時拋出例外
      */
-    public function createUser(array $data): User 
+    public function createUser(array $data): User
     {
         return User::create([
             'name' => $data['name'],
             'email' => $data['email'],
             'phone' => $data['phone'] ?? null,
             'password' => $data['password'],
+            'role_id' => $data['role_id'] ?? null,
         ]);
     }
 

--- a/database/migrations/2026_01_27_235326_create_roles_table.php
+++ b/database/migrations/2026_01_27_235326_create_roles_table.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('roles', function (Blueprint $table) {
+            $table->id();
+            $table->string('name')->unique()->comment('角色代碼 (admin, user)');
+            $table->string('display_name')->comment('角色顯示名稱');
+            $table->text('description')->nullable()->comment('角色描述');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('roles');
+    }
+};

--- a/database/migrations/2026_01_27_235428_add_role_id_to_users_table.php
+++ b/database/migrations/2026_01_27_235428_add_role_id_to_users_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->foreignId('role_id')->after('phone')->nullable()->comment('角色 ID');
+
+            // 外鍵約束
+            $table->foreign('role_id')->references('id')->on('roles')->onDelete('set null');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->dropForeign(['role_id']);
+            $table->dropColumn('role_id');
+        });
+    }
+};

--- a/database/seeders/AdminUserSeeder.php
+++ b/database/seeders/AdminUserSeeder.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Database\Seeders;
+
+use Illuminate\Database\Console\Seeds\WithoutModelEvents;
+use Illuminate\Database\Seeder;
+use App\Models\User;
+use App\Models\Role;
+
+class AdminUserSeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     */
+    public function run(): void
+    {
+        // 取得管理者角色
+        $adminRole = Role::where('name', Role::ADMIN)->first();
+
+        if (!$adminRole) {
+            $this->command->error('請先執行 RolesTableSeeder！');
+            return;
+        }
+
+        // 檢查是否已存在管理者帳號
+        $existingAdmin = User::where('email', 'admin@example.com')->first();
+
+        if ($existingAdmin) {
+            $this->command->warn('管理者帳號已存在，跳過建立。');
+            return;
+        }
+
+        // 建立管理者帳號
+        User::create([
+            'name' => '系統管理員',
+            'email' => 'admin@example.com',
+            'password' => 'admin123456',  // Model 會自動 hash
+            'phone' => '0912345678',
+            'role_id' => $adminRole->id,
+        ]);
+
+        $this->command->info('管理者帳號建立成功！');
+        $this->command->info('Email: admin@example.com');
+        $this->command->info('Password: admin123456');
+    }
+}

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -12,11 +12,12 @@ class DatabaseSeeder extends Seeder
      */
     public function run(): void
     {
-        // \App\Models\User::factory(10)->create();
+        // 1. 先建立角色資料（基礎資料）
+        $this->call(RolesTableSeeder::class);
 
-        // \App\Models\User::factory()->create([
-        //     'name' => 'Test User',
-        //     'email' => 'test@example.com',
-        // ]);
+        // 2. 再建立管理員帳號（依賴角色資料）
+        $this->call(AdminUserSeeder::class);
+
+        $this->command->info('所有種子資料建立完成！');
     }
 }

--- a/database/seeders/RolesTableSeeder.php
+++ b/database/seeders/RolesTableSeeder.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Database\Seeders;
+
+use Illuminate\Database\Console\Seeds\WithoutModelEvents;
+use Illuminate\Database\Seeder;
+use App\Models\Role;
+
+class RolesTableSeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     */
+    public function run(): void
+    {
+        // 檢查是否已存在角色資料
+        if (Role::count() > 0) {
+            $this->command->warn('角色資料已存在，跳過建立。');
+            return;
+        }
+
+        // 建立預設角色
+        Role::create([
+            'name' => Role::ADMIN,
+            'display_name' => '管理者',
+            'description' => '系統管理員，擁有所有權限',
+        ]);
+
+        Role::create([
+            'name' => Role::USER,
+            'display_name' => '一般使用者',
+            'description' => '一般註冊使用者',
+        ]);
+
+        $this->command->info('角色資料建立成功！');
+    }
+}

--- a/tests/Feature/UserLoginTest.php
+++ b/tests/Feature/UserLoginTest.php
@@ -4,6 +4,7 @@ namespace Tests\Feature;
 
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use App\Models\User;
+use App\Models\Role;
 use Tests\TestCase;
 use Illuminate\Support\Facades\Hash;
 
@@ -14,6 +15,22 @@ class UserLoginTest extends TestCase
      * 確保測試之間互不影響
      */
     use RefreshDatabase;
+
+    /**
+     * 每個測試前執行
+     * 建立必要的角色資料
+     */
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        // 建立一般使用者角色
+        Role::create([
+            'name' => Role::USER,
+            'display_name' => '一般使用者',
+            'description' => '一般註冊使用者',
+        ]);
+    }
 
     /**
      * 測試：使用者可以成功登入

--- a/tests/Feature/UserRegistrationTest.php
+++ b/tests/Feature/UserRegistrationTest.php
@@ -5,6 +5,7 @@ namespace Tests\Feature;
 use Tests\TestCase;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use App\Models\User;
+use App\Models\Role;
 
 /**
  * 使用者註冊 API 測試
@@ -18,6 +19,22 @@ class UserRegistrationTest extends TestCase
      * 確保測試之間互不影響
      */
     use RefreshDatabase;
+
+    /**
+     * 每個測試前執行
+     * 建立必要的角色資料
+     */
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        // 建立一般使用者角色（註冊功能需要）
+        Role::create([
+            'name' => Role::USER,
+            'display_name' => '一般使用者',
+            'description' => '一般註冊使用者',
+        ]);
+    }
 
     /**
      * 測試：使用者可以成功註冊

--- a/tests/Unit/UserServiceTest.php
+++ b/tests/Unit/UserServiceTest.php
@@ -5,6 +5,7 @@ namespace Tests\Unit;
 use Tests\TestCase;
 use App\Services\UserService;
 use App\Repositories\UserRepository;
+use App\Repositories\RoleRepository;
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Exception;
@@ -41,14 +42,17 @@ class UserServiceTest extends TestCase
         ]);
 
         // 2. Mock UserRepository - 只 mock Repository，不 mock Facade
-        $mockRepository = Mockery::mock(UserRepository::class);
-        $mockRepository->shouldReceive('findByEmail')
+        $mockUserRepository = Mockery::mock(UserRepository::class);
+        $mockUserRepository->shouldReceive('findByEmail')
             ->once()
             ->with('test@example.com')
             ->andReturn($user);
 
-        // 3. 建立 UserService，注入 mock 的 Repository
-        $userService = new UserService($mockRepository);
+        // 3. Mock RoleRepository（login 方法不需要，但 constructor 需要）
+        $mockRoleRepository = Mockery::mock(RoleRepository::class);
+
+        // 4. 建立 UserService，注入 mock 的 Repository
+        $userService = new UserService($mockUserRepository, $mockRoleRepository);
 
         // === Act（執行）===
         $result = $userService->login([
@@ -72,13 +76,15 @@ class UserServiceTest extends TestCase
     public function test_login_throws_exception_when_user_not_found(): void
     {
         // Arrange
-        $mockRepository = Mockery::mock(UserRepository::class);
-        $mockRepository->shouldReceive('findByEmail')
+        $mockUserRepository = Mockery::mock(UserRepository::class);
+        $mockUserRepository->shouldReceive('findByEmail')
             ->once()
             ->with('notfound@example.com')
             ->andReturn(null);
 
-        $userService = new UserService($mockRepository);
+        $mockRoleRepository = Mockery::mock(RoleRepository::class);
+
+        $userService = new UserService($mockUserRepository, $mockRoleRepository);
 
         // Assert
         $this->expectException(Exception::class);
@@ -103,12 +109,14 @@ class UserServiceTest extends TestCase
             'password' => 'correct-password',
         ]);
 
-        $mockRepository = Mockery::mock(UserRepository::class);
-        $mockRepository->shouldReceive('findByEmail')
+        $mockUserRepository = Mockery::mock(UserRepository::class);
+        $mockUserRepository->shouldReceive('findByEmail')
             ->once()
             ->andReturn($user);
 
-        $userService = new UserService($mockRepository);
+        $mockRoleRepository = Mockery::mock(RoleRepository::class);
+
+        $userService = new UserService($mockUserRepository, $mockRoleRepository);
 
         // Assert
         $this->expectException(Exception::class);


### PR DESCRIPTION
- 建立 roles 資料表與 Role Model
- users 表新增 role_id 欄位建立角色關聯
- 新增 RoleRepository 處理角色資料查詢
- UserService 透過 RoleRepository 取得角色，遵循分層架構
- 新增 AdminMiddleware 檢查管理員權限
- User Model 加入角色關聯與權限檢查方法（isAdmin, isUser, hasRole）
- 建立 RolesTableSeeder 初始化預設角色（管理者、一般使用者）
- 建立 AdminUserSeeder 建立預設管理員帳號
- DatabaseSeeder 統一管理種子資料執行順序
- 註冊時自動分配一般使用者角色
- Kernel 註冊 admin middleware 別名