### PR TITLE
feat(item): 新增商品管理功能與管理員權限控制

### DIFF
--- a/app/Http/Controllers/Api/ItemController.php
+++ b/app/Http/Controllers/Api/ItemController.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use App\Http\Requests\CreateItemRequest;
+use App\Http\Resources\ItemResource;
+use App\Services\ItemService;
+use Exception;
+use Illuminate\Http\Response;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+
+class ItemController extends Controller
+{
+    public function __construct(
+        private ItemService $itemService
+    ) {}
+
+    /**
+     * Display a listing of the resource.
+     */
+    public function index()
+    {
+        //
+    }
+
+    /**
+     * 建立商品
+     * @param CreateItemRequest $request
+     * @return JsonResponse 
+     */
+    public function store(CreateItemRequest $request): JsonResponse
+    {
+        try {
+            $item = $this->itemService->createItem($request->validated());
+
+            return response()->json([
+                'success' => true,
+                'status' => Response::HTTP_CREATED,
+                'message' => '商品建立成功',
+                'data' => new ItemResource($item)
+            ], Response::HTTP_CREATED);
+        } catch (Exception $e) {
+            return response()->json([
+                'success' => false,
+                'status' => $e->getCode() ?: Response::HTTP_INTERNAL_SERVER_ERROR,
+                'message' => '伺服器錯誤，請稍後再試',
+                'data' => null
+            ], $e->getCode() ?: Response::HTTP_INTERNAL_SERVER_ERROR);
+        }
+    }
+
+    /**
+     * Display the specified resource.
+     */
+    public function show(string $id)
+    {
+        //
+    }
+
+    /**
+     * Update the specified resource in storage.
+     */
+    public function update(Request $request, string $id)
+    {
+        //
+    }
+
+    /**
+     * Remove the specified resource from storage.
+     */
+    public function destroy(string $id)
+    {
+        //
+    }
+}

--- a/app/Http/Requests/CreateItemRequest.php
+++ b/app/Http/Requests/CreateItemRequest.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class CreateItemRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, \Illuminate\Contracts\Validation\ValidationRule|array<mixed>|string>
+     */
+    public function rules(): array
+    {
+        return [
+            'name' => 'required|string|max:100',
+            'price' => 'required|integer|min:0',
+            'stock' => 'required|integer|min:0',
+            'status' => 'required|in:1,2' // 1 草稿, 2 上架
+        ];
+    }
+
+    /**
+     * 自訂錯誤訊息
+     */
+    public function messages(): array
+    {
+        return [
+            'name.required' => '商品名稱必填',
+            'name.max' => '商品名稱最多100個字元',
+            'price.required' => '商品價格必填',
+            'price.integer' => '商品價格只能為數字',
+            'price.min' => '商品價格最低為0',
+            'stock.required' => '庫存量為必填',
+            'stock.integer' => '庫存量只能為數字',
+            'stock.min' => '庫存最少必須為0',
+            'status.required' => '商品狀態必填',
+            'status.in' => '狀態僅允許 1(草稿)、2(發布)'
+        ]; 
+    } 
+}

--- a/app/Http/Resources/ItemResource.php
+++ b/app/Http/Resources/ItemResource.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace App\Http\Resources;
+
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+use App\Http\Resources\Traits\FormatTimestamps;
+
+class ItemResource extends JsonResource
+{
+    use FormatTimestamps;
+
+    /**
+     * Transform the resource into an array.
+     *
+     * @return array<string, mixed>
+     */
+    public function toArray(Request $request): array
+    {
+        return [
+            'id' => $this->id,
+            'item_no' => $this->item_no,
+            'name' => $this->name,
+            'description' => $this->description,
+            'price' => $this->price,
+            'stock' => $this->stock,
+            'status' => $this->status,
+            'image' =>  $this->image,
+            'user' => [
+                'user_id' => $this->user->id,
+                'name' => $this->user->name
+            ],
+            'category_id' => $this->category_id,
+            'brand_id' => $this->brand_id,
+            'created_at' => $this->formatDateTime($this->created_at),
+            'updated_at' => $this->formatDateTime($this->updated_at),
+        ];
+    }
+}

--- a/app/Models/Item.php
+++ b/app/Models/Item.php
@@ -1,0 +1,147 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class Item extends Model
+{
+    use HasFactory;
+
+    /**
+     * 商品狀態常數
+     */
+    const STATUS_DRAFT = 1;       // 草稿
+    const STATUS_PUBLISHED = 2;   // 上架
+    const STATUS_UNPUBLISHED = 3; // 下架
+
+    /**
+     * 可批量賦值的屬性
+     */
+    protected $fillable = [
+        'item_no',
+        'name',
+        'description',
+        'price',
+        'stock',
+        'status',
+        'image',
+        'user_id',
+        'category_id',
+        'brand_id',
+    ];
+
+    /**
+     * 屬性類型轉換
+     */
+    protected $casts = [
+        'price' => 'integer',
+        'stock' => 'integer',
+        'status' => 'integer',
+    ];
+
+    /**
+     * 模型啟動方法
+     * 在商品建立後自動生成 item_no
+     */
+    protected static function boot()
+    {
+        parent::boot();
+
+        // 在商品建立後自動生成 item_no
+        static::created(function ($item) {
+            if (empty($item->item_no)) {
+                $item->item_no = self::generateItemNo($item->id);
+                $item->save();
+            }
+        });
+    }
+
+    /**
+     * 生成商品編號 item_no
+     * 規則：ITEM + 10位數補零的 id
+     * 例如：id=1 -> ITEM0000000001, id=999 -> ITEM0000000999
+     *
+     * @param int $id
+     * @return string
+     */
+    public static function generateItemNo(int $id): string
+    {
+        return 'ITEM' . str_pad($id, 10, '0', STR_PAD_LEFT);
+    }
+
+    /**
+     * 檢查商品是否為草稿狀態
+     *
+     * @return bool
+     */
+    public function isDraft(): bool
+    {
+        return $this->status === self::STATUS_DRAFT;
+    }
+
+    /**
+     * 檢查商品是否已上架
+     *
+     * @return bool
+     */
+    public function isPublished(): bool
+    {
+        return $this->status === self::STATUS_PUBLISHED;
+    }
+
+    /**
+     * 檢查商品是否已下架
+     *
+     * @return bool
+     */
+    public function isUnpublished(): bool
+    {
+        return $this->status === self::STATUS_UNPUBLISHED;
+    }
+
+    /**
+     * 取得狀態文字
+     *
+     * @return string
+     */
+    public function getStatusText(): string
+    {
+        return match ($this->status) {
+            self::STATUS_DRAFT => '草稿',
+            self::STATUS_PUBLISHED => '上架',
+            self::STATUS_UNPUBLISHED => '下架',
+            default => '未知',
+        };
+    }
+
+    /**
+     * 關聯：商品分類（預留）
+     * 未來建立 Category Model 後取消註解
+     */
+    // public function category()
+    // {
+    //     return $this->belongsTo(Category::class);
+    // }
+
+    /**
+     * 關聯：商品品牌（預留）
+     * 未來建立 Brand Model 後取消註解
+     */
+    // public function brand()
+    // {
+    //     return $this->belongsTo(Brand::class);
+    // }
+
+    /**
+     * 關聯：商品建立者
+     * 一個商品屬於一個使用者（建立者）
+     *
+     * @return \Illuminate\Database\Eloquent\Relations\BelongsTo
+     */
+    public function user()
+    {
+        return $this->belongsTo(User::class);
+    }
+}

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -78,6 +78,16 @@ class User extends Authenticatable implements JWTSubject
     }
 
     /**
+     * 一個使用者有多個商品
+     *
+     * @return \Illuminate\Database\Eloquent\Relations\HasMany
+     */
+    public function items()
+    {
+        return $this->hasMany(Item::class);
+    }
+
+    /**
      * 一個使用者屬於一個角色
      *
      * @return \Illuminate\Database\Eloquent\Relations\BelongsTo

--- a/app/Repositories/ItemRepository.php
+++ b/app/Repositories/ItemRepository.php
@@ -1,0 +1,24 @@
+<?php 
+
+namespace App\Repositories;
+
+use App\Models\Item;
+use Illuminate\Database\Eloquent\ModelNotFoundException;
+
+/**
+ * Class ItemRepository
+ * 
+ * 處理商品相關資料表 (items) 有關的資料存取邏輯
+ */
+class ItemRepository
+{
+    /**
+     * 新增商品
+     * @param array $data 要新增之商品資料
+     * @return \App\Models\Item 儲存後的商品模型
+     */
+    public function createItem(array $data): Item
+    {
+        return Item::create($data);
+    }
+}

--- a/app/Services/ItemService.php
+++ b/app/Services/ItemService.php
@@ -1,0 +1,42 @@
+<?php 
+
+namespace App\Services;
+
+use App\Models\Item;
+use App\Repositories\ItemRepository;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\gate;
+use Illuminate\Auth\Access\AuthorizationException;
+use Illuminate\Database\Eloquent\ModelNotFoundException;
+
+
+/**
+ * Class ItemService
+ * 負責處裡商品相關邏輯層操作
+ */
+class ItemService
+{
+    public function __construct(
+        private ItemRepository $itemRepository
+    ) {}
+    
+
+    /**
+     * 建立商品
+     *
+     * @param array $data
+     * @return \App\Models\Item
+     */
+    public function createItem(array $data): Item
+    {
+        // 加入當前登入的管理員 ID
+        // 明確指定的方式
+        $data['user_id'] = Auth::guard('api')->id();
+
+        // 建立商品
+        $item = $this->itemRepository->createItem($data);
+
+        // 預載建立者資訊
+        return $item->load('user');
+    }
+}

--- a/app/Services/PostService.php
+++ b/app/Services/PostService.php
@@ -28,6 +28,7 @@ class PostService
     public function createPost(array $data): Post
     {
         // 加上目前使用者 id
+        // 簡潔，Laravel 會自動選擇當前 guard
         $data['user_id'] = Auth::id();
 
         $post = $this->postRepository->createPost($data);

--- a/app/Swagger/Item.php
+++ b/app/Swagger/Item.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace App\Swagger;
+
+/**
+ * @OA\Post(
+ *     path="/api/items",
+ *     summary="建立商品",
+ *     tags={"Item"},
+ *     description="管理員建立新商品 API，需要管理員權限",
+ *     operationId="createItem",
+ *     security={{"bearerAuth":{}}},
+ *
+ *     @OA\RequestBody(
+ *         required=true,
+ *         @OA\JsonContent(ref="#/components/schemas/CreateItemRequest")
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=201,
+ *         description="商品建立成功",
+ *         @OA\JsonContent(ref="#/components/schemas/CreateItemResponse")
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=401,
+ *         description="尚未授權",
+ *         @OA\JsonContent(
+ *             @OA\Property(property="success", type="boolean", example=false),
+ *             @OA\Property(property="status", type="integer", example=401),
+ *             @OA\Property(property="message", type="string", example="尚未授權，請登入"),
+ *             @OA\Property(property="data", type="string", nullable=true, example=null)
+ *         )
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=403,
+ *         description="權限不足",
+ *         @OA\JsonContent(
+ *             @OA\Property(property="success", type="boolean", example=false),
+ *             @OA\Property(property="status", type="integer", example=403),
+ *             @OA\Property(property="message", type="string", example="權限不足，僅限管理者使用"),
+ *             @OA\Property(property="data", type="string", nullable=true, example=null)
+ *         )
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=422,
+ *         description="驗證失敗",
+ *         @OA\JsonContent(ref="#/components/schemas/CreateItemValidationError")
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=500,
+ *         description="伺服器錯誤",
+ *         @OA\JsonContent(
+ *             @OA\Property(property="success", type="boolean", example=false),
+ *             @OA\Property(property="status", type="integer", example=500),
+ *             @OA\Property(property="message", type="string", example="商品建立失敗：內部伺服器錯誤"),
+ *             @OA\Property(property="data", type="string", nullable=true, example=null)
+ *         )
+ *     )
+ * )
+ */
+
+class Item {}

--- a/app/Swagger/Schemas/Item/CreateItemRequestSchema.php
+++ b/app/Swagger/Schemas/Item/CreateItemRequestSchema.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Swagger\Schemas\Item;
+
+/**
+ * @OA\Schema(
+ *     schema="CreateItemRequest",
+ *     required={"name", "price", "stock", "status"},
+ *     @OA\Property(property="name", type="string", maxLength=100, example="iPhone 15 Pro", description="商品名稱"),
+ *     @OA\Property(property="description", type="string", example="最新款 iPhone，256GB 空間", nullable=true, description="商品描述"),
+ *     @OA\Property(property="price", type="integer", minimum=0, example=35900, description="商品價格（整數）"),
+ *     @OA\Property(property="stock", type="integer", minimum=0, example=100, description="庫存數量"),
+ *     @OA\Property(
+ *         property="status",
+ *         type="integer",
+ *         enum={1, 2},
+ *         example=2,
+ *         description="商品狀態 (1:草稿 2:上架)"
+ *     ),
+ *     @OA\Property(property="image", type="string", example="/images/iphone15pro.jpg", nullable=true, description="商品主圖片路徑")
+ * )
+ */
+
+class CreateItemRequestSchema {}

--- a/app/Swagger/Schemas/Item/CreateItemResponseSchema.php
+++ b/app/Swagger/Schemas/Item/CreateItemResponseSchema.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace App\Swagger\Schemas\Item;
+
+/**
+ * @OA\Schema(
+ *     schema="CreateItemResponse",
+ *     @OA\Property(property="success", type="boolean", example=true),
+ *     @OA\Property(property="status", type="integer", example=201),
+ *     @OA\Property(property="message", type="string", example="商品建立成功"),
+ *     @OA\Property(
+ *         property="data",
+ *         type="object",
+ *         @OA\Property(property="id", type="integer", example=1),
+ *         @OA\Property(property="item_no", type="string", example="ITEM0000000001"),
+ *         @OA\Property(property="name", type="string", example="iPhone 15 Pro"),
+ *         @OA\Property(property="description", type="string", nullable=true, example="最新款 iPhone，256GB 空間"),
+ *         @OA\Property(property="price", type="integer", example=35900),
+ *         @OA\Property(property="stock", type="integer", example=100),
+ *         @OA\Property(property="status", type="integer", example=2, description="1:草稿 2:上架 3:下架"),
+ *         @OA\Property(property="image", type="string", nullable=true, example="/images/iphone15pro.jpg"),
+ *         @OA\Property(
+ *             property="user",
+ *             type="object",
+ *             @OA\Property(property="user_id", type="integer", example=5),
+ *             @OA\Property(property="name", type="string", example="系統管理員")
+ *         ),
+ *         @OA\Property(property="category_id", type="integer", nullable=true, example=null),
+ *         @OA\Property(property="brand_id", type="integer", nullable=true, example=null),
+ *         @OA\Property(property="created_at", type="string", format="date-time", example="2026-01-29 23:55:58"),
+ *         @OA\Property(property="updated_at", type="string", format="date-time", example="2026-01-29 23:55:58")
+ *     )
+ * )
+ */
+
+class CreateItemResponseSchema {}

--- a/app/Swagger/Schemas/Item/CreateItemValidationErrorSchema.php
+++ b/app/Swagger/Schemas/Item/CreateItemValidationErrorSchema.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace App\Swagger\Schemas\Item;
+
+/**
+ * @OA\Schema(
+ *     schema="CreateItemValidationError",
+ *     @OA\Property(property="success", type="boolean", example=false),
+ *     @OA\Property(property="status", type="integer", example=422),
+ *     @OA\Property(property="message", type="string", example="驗證失敗"),
+ *     @OA\Property(
+ *         property="errors",
+ *         type="object",
+ *         @OA\Property(
+ *             property="name",
+ *             type="array",
+ *             @OA\Items(type="string", example="商品名稱必填")
+ *         ),
+ *         @OA\Property(
+ *             property="price",
+ *             type="array",
+ *             @OA\Items(type="string", example="商品價格必填")
+ *         ),
+ *         @OA\Property(
+ *             property="stock",
+ *             type="array",
+ *             @OA\Items(type="string", example="庫存量為必填")
+ *         ),
+ *         @OA\Property(
+ *             property="status",
+ *             type="array",
+ *             @OA\Items(type="string", example="商品狀態必填")
+ *         )
+ *     )
+ * )
+ */
+
+class CreateItemValidationErrorSchema {}

--- a/database/migrations/2026_01_28_005116_create_items_table.php
+++ b/database/migrations/2026_01_28_005116_create_items_table.php
@@ -1,0 +1,56 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('items', function (Blueprint $table) {
+            // 主鍵（內部使用，自動遞增）
+            $table->id();
+
+            // 商品編號（對外使用，系統自動生成）
+            $table->string('item_no', 50)->unique()->nullable()->comment('商品編號 - 對外顯示與查詢使用（建立後自動生成）');
+
+            // 基本資訊
+            $table->string('name')->comment('商品名稱');
+            $table->text('description')->nullable()->comment('商品描述');
+
+            // 價格與庫存（價格為整數，不得小於0）
+            $table->unsignedInteger('price')->default(0)->comment('商品價格（整數）');
+            $table->integer('stock')->default(0)->comment('庫存數量');
+
+            // 商品狀態：1=草稿, 2=上架, 3=下架
+            $table->tinyInteger('status')->default(1)->comment('商品狀態 (1:草稿 2:上架 3:下架)');
+
+            // 圖片（簡易版本，未來可擴充成圖片表）
+            $table->string('image')->nullable()->comment('商品主圖片路徑');
+
+            // 商品建立者
+            $table->foreignId('user_id')->nullable()->comment('商品建立者 ID');
+
+            // 預留未來關聯欄位
+            $table->foreignId('category_id')->nullable()->comment('商品分類 ID (預留)');
+            $table->foreignId('brand_id')->nullable()->comment('商品品牌 ID (預留)');
+
+            $table->foreign('user_id')->references('id')->on('users')->nullOnDelete();
+
+            // 時間戳記
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('items');
+    }
+};

--- a/routes/api.php
+++ b/routes/api.php
@@ -1,8 +1,9 @@
 <?php
 
-use App\Http\Controllers\Api\UserController;
-use App\Http\Controllers\Api\PostController;
 use App\Http\Controllers\Api\CommentController;
+use App\Http\Controllers\Api\ItemController;
+use App\Http\Controllers\Api\PostController;
+use App\Http\Controllers\Api\UserController;
 use App\Http\Controllers\Api\ShortUrlController;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Route;
@@ -56,6 +57,14 @@ Route::middleware('auth:api')->group(function () {
         Route::post('/{post}/comments', [CommentController::class, 'store']);
         // 修改留言
         Route::PUT('/{post}/comments/{comment}', [CommentController::class, 'update']);
+    });
+
+    // 管理者才能做的
+    Route::middleware('admin')->group(function () {
+        // 商品
+        Route::prefix('items')->group(function () {
+            Route::post('/', [ItemController::class, 'store']);
+        });
     });
 
     // 短網址


### PR DESCRIPTION
- 建立 items 資料表包含商品基本資訊（名稱、價格、庫存、狀態）
- 商品編號 item_no 使用 id 自動生成（ITEM00000001 格式）
- 商品狀態支援草稿(1)、上架(2)、下架(3)
- 商品建立者關聯 user_id，記錄哪位管理員建立
- 預留 category_id、brand_id 欄位供未來擴充
- Item Model 實作狀態常數與狀態檢查方法
- Item Model boot 事件自動生成 item_no
- ItemRepository 處理商品資料存取
- ItemService 處理商品業務邏輯，自動加入建立者 ID
- ItemController 處理商品 API 請求
- CreateItemRequest 驗證商品建立欄位
- ItemResource 格式化商品回應資料，包含建立者資訊
- 路由限制僅管理員可建立商品（admin middleware）
- User Model 加入 items 關聯方法
- Swagger 文檔包含建立商品 API 規格
- Swagger 定義 401、403、422、500 錯誤回應格式