### PR TITLE
fix(docker): 修正 Redis 持久化與 Elasticsearch 網路設定

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -46,6 +46,8 @@ services:
     container_name: redis 
     ports:
       - "6379:6379"
+    volumes:
+      - redis_data:/data
     
   # Nginx 服務
   nginx:
@@ -75,8 +77,11 @@ services:
       # JVM 記憶體
       - ES_JAVA_OPTS=-Xms${ES_HEAP_SIZE:-512m} -Xmx${ES_HEAP_SIZE:-512m}
 
+      - network.host=0.0.0.0
+      - http.host=0.0.0.0
+
       # 設定 bootstrap password（正式環境必須）
-      - ELASTIC_PASSWORD=${ELASTIC_PASSWORD}
+      # - ELASTIC_PASSWORD=${ELASTIC_PASSWORD}
     ports:
       - "${ES_PORT:-9200}:9200"
     volumes:
@@ -113,4 +118,5 @@ services:
 # 定義 volume
 volumes:
   db_data:
+  redis_data:
   es_data:  # ES 資料持久化


### PR DESCRIPTION
- Redis 新增 volumes 持久化資料，避免容器重啟後資料丟失
- Elasticsearch 設定 network.host 和 http.host 為 0.0.0.0，允許容器外部訪問
- 暫時注解 ELASTIC_PASSWORD（開發環境不需要安全認證）
- 新增 redis_data volume 定義